### PR TITLE
MINOR: Fix linting errors in tests & AssetAdmin.js

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,1 @@
-javascript/**/tests/**/*.js
-javascript/src/AssetAdmin.js
 javascript/dist/

--- a/javascript/AssetAdmin.js
+++ b/javascript/AssetAdmin.js
@@ -1,78 +1,88 @@
+/* global jQuery, ss */
+
 /**
  * File: AssetAdmin.js
  */
 
-(function($) {
-	$.entwine('ss', function($){
-		/**
-		 * Load folder detail view via controller methods
-		 * rather than built-in GridField view (which is only geared towards showing files).
-		 */
-		$('.AssetAdmin.cms-edit-form .ss-gridfield-item').entwine({
-			onclick: function(e) {
-				// Let actions do their own thing
-				if($(e.target).closest('.action').length) {
-					this._super(e);
-					return;
-				}
+((jQuery) => {
+  jQuery.entwine('ss', ($) => {
+    /**
+     * Load folder detail view via controller methods
+     * rather than built-in GridField view (which is only geared towards showing files).
+     */
+    $('.AssetAdmin.cms-edit-form .ss-gridfield-item').entwine({
+      onclick: (e) => {
+        // Let actions do their own thing
+        if ($(e.target).closest('.action').length) {
+          this._super(e);
+          return undefined;
+        }
 
-				var grid = this.closest('.ss-gridfield');
-				if(this.data('class') == 'Folder') {
-					var url = grid.data('urlFolderTemplate').replace('%s', this.data('id'));
-					$('.cms-container').loadPanel(url);
-					return false;
-				}
+        const grid = this.closest('.ss-gridfield');
+        if (this.data('class') === 'Folder') {
+          const url = grid.data('urlFolderTemplate').replace('%s', this.data('id'));
+          $('.cms-container').loadPanel(url);
+          return false;
+        }
 
-				this._super(e);
-			}
-		});
+        this._super(e);
+        return undefined;
+      },
+    });
 
-		$('.AssetAdmin.cms-edit-form .ss-gridfield .col-buttons .action.gridfield-button-delete, .AssetAdmin.cms-edit-form .Actions button.action.action-delete').entwine({
-			onclick: function(e) {
-				var msg;
-				if(this.closest('.ss-gridfield-item').data('class') == 'Folder') {
-					msg = ss.i18n._t('AssetAdmin.ConfirmDelete');
-				} else {
-					msg = ss.i18n._t('TABLEFIELD.DELETECONFIRMMESSAGE');
-				}
-				if(!confirm(msg)) return false;
+    const selector = '.AssetAdmin.cms-edit-form .ss-gridfield .col-buttons .action.gridfield-button-delete, '
+      + '.AssetAdmin.cms-edit-form .Actions button.action.action-delete';
+    $(selector).entwine({
+      onclick: (e) => {
+        let msg;
+        if (this.closest('.ss-gridfield-item').data('class') === 'Folder') {
+          msg = ss.i18n._t('AssetAdmin.ConfirmDelete');
+        } else {
+          msg = ss.i18n._t('TABLEFIELD.DELETECONFIRMMESSAGE');
+        }
 
-				this.getGridField().reload({data: [{name: this.attr('name'), value: this.val()}]});
-				e.preventDefault();
-				return false;
-			}
-		});
+        // eslint-disable-next-line no-alert
+        if (!confirm(msg)) return false;
 
-		$('.AssetAdmin.cms-edit-form :submit[name=action_delete]').entwine({
-			onclick: function(e) {
-				if(!confirm(ss.i18n._t('AssetAdmin.ConfirmDelete'))) return false;
-				else this._super(e);
-			}
-		});
+        this.getGridField().reload({ data: [{ name: this.attr('name'), value: this.val() }] });
+        e.preventDefault();
+        return false;
+      },
+    });
 
-		/**
-		 * Prompt for a new foldername, rather than using dedicated form.
-		 * Better usability, but less flexibility in terms of inputs and validation.
-		 * Mainly necessary because AssetAdmin->AddForm() returns don't play nicely
-		 * with the nested AssetAdmin->EditForm() DOM structures.
-		 */
-		$('.AssetAdmin .cms-add-folder-link').entwine({
-			onclick: function(e) {
-				var name = prompt(ss.i18n._t('Folder.Name'));
-				if(!name) return false;
+    $('.AssetAdmin.cms-edit-form :submit[name=action_delete]').entwine({
+      onclick: (e) => {
+        // eslint-disable-next-line no-alert
+        if (!confirm(ss.i18n._t('AssetAdmin.ConfirmDelete'))) return false;
+        this._super(e);
+        return undefined;
+      },
+    });
 
-				this.closest('.cms-container').loadPanel(this.data('url') + '&Name=' + name);
-				return false;
-			}
-		});
+    /**
+     * Prompt for a new foldername, rather than using dedicated form.
+     * Better usability, but less flexibility in terms of inputs and validation.
+     * Mainly necessary because AssetAdmin->AddForm() returns don't play nicely
+     * with the nested AssetAdmin->EditForm() DOM structures.
+     */
+    $('.AssetAdmin .cms-add-folder-link').entwine({
+      onclick: () => {
+        // eslint-disable-next-line no-alert
+        const name = prompt(ss.i18n._t('Folder.Name'));
+        if (!name) return false;
 
-		$('.AssetAdmin .gallery__back').entwine({
-			onmatch: function () {
-				$('.cms-add-folder-link').css('margin-left', 32);
-			},
-			onunmatch: function () {
-				$('.cms-add-folder-link').css('margin-left', 0);
-			}
-		})
-	});
-}(jQuery));
+        this.closest('.cms-container').loadPanel(`${this.data('url')}&Name${name}`);
+        return false;
+      },
+    });
+
+    $('.AssetAdmin .gallery__back').entwine({
+      onmatch: () => {
+        $('.cms-add-folder-link').css('margin-left', 32);
+      },
+      onunmatch: () => {
+        $('.cms-add-folder-link').css('margin-left', 0);
+      },
+    });
+  });
+})(jQuery);

--- a/javascript/src/components/bulk-actions/tests/bulk-actions-component-test.js
+++ b/javascript/src/components/bulk-actions/tests/bulk-actions-component-test.js
@@ -8,7 +8,6 @@ const ReactTestUtils = require('react-addons-test-utils');
 const BulkActionsComponent = require('../index.js').BulkActionsComponent;
 
 describe('BulkActionsComponent', () => {
-
   let props;
   const deleteActionSpy = jasmine.createSpy('deleteAction');
 
@@ -34,42 +33,42 @@ describe('BulkActionsComponent', () => {
   describe('getOptionByValue()', () => {
     let bulkActions;
 
-    beforeEach(function () {
+    beforeEach(() => {
       bulkActions = ReactTestUtils.renderIntoDocument(
         <BulkActionsComponent {...props} />
       );
     });
 
-    it('should return the option which matches the given value', function () {
+    it('should return the option which matches the given value', () => {
       expect(bulkActions.getOptionByValue('delete').value).toBe('delete');
     });
 
-    it('should return null if no option matches the given value', function () {
+    it('should return null if no option matches the given value', () => {
       expect(bulkActions.getOptionByValue('destroyCMS')).toBe(null);
     });
   });
 
-  describe('getSelectedFiles()', function () {
-    var bulkActions;
+  describe('getSelectedFiles()', () => {
+    let bulkActions;
 
-    beforeEach(function () {
+    beforeEach(() => {
       bulkActions = ReactTestUtils.renderIntoDocument(
         <BulkActionsComponent {...props} />
       );
     });
 
-    it('should return the option which matches the given value', function () {
+    it('should return the option which matches the given value', () => {
       expect(bulkActions.getSelectedFiles()[0]).toBe(1);
     });
   });
 
-  describe('applyAction()', function () {
-    var bulkActions;
+  describe('applyAction()', () => {
+    let bulkActions;
 
-    beforeEach(function () {
+    beforeEach(() => {
       props.backend = {
-        delete: jest.genMockFunction()
-      }
+        delete: jest.genMockFunction(),
+      };
       props.getSelectedFiles = jest.genMockFunction();
 
       bulkActions = ReactTestUtils.renderIntoDocument(
@@ -77,7 +76,7 @@ describe('BulkActionsComponent', () => {
       );
     });
 
-    it('should apply the given action', function () {
+    it('should apply the given action', () => {
       props.getSelectedFiles.mockReturnValueOnce('file1');
 
       bulkActions.applyAction('delete');
@@ -85,40 +84,41 @@ describe('BulkActionsComponent', () => {
       expect(deleteActionSpy).toHaveBeenCalled();
     });
 
-    it('should return false if there are no matching actions', function () {
+    it('should return false if there are no matching actions', () => {
       expect(bulkActions.applyAction('destroyCMS')).toBe(false);
     });
   });
 
-  describe('onChangeValue()', function () {
-    var bulkActions, event;
+  describe('onChangeValue()', () => {
+    let bulkActions;
+    let event;
 
-    beforeEach(function () {
+    beforeEach(() => {
       bulkActions = ReactTestUtils.renderIntoDocument(
           <BulkActionsComponent {...props} />
       );
 
       event = {
         target: {
-          value: 'delete'
-        }
-      }
+          value: 'delete',
+        },
+      };
 
       bulkActions.getOptionByValue = jest.genMockFunction();
       bulkActions.applyAction = jest.genMockFunction();
     });
 
-    it('should return undefined if no valid option is selected', function () {
+    it('should return undefined if no valid option is selected', () => {
       bulkActions.getOptionByValue.mockReturnValueOnce(null);
 
       expect(bulkActions.onChangeValue(event)).toBe(undefined);
     });
 
-    it('should ask user for confirmation if the action is destructive', function () {
-      var mock = jest.genMockFunction(),
-        originalConfirm = window.confirm;
+    it('should ask user for confirmation if the action is destructive', () => {
+      const mock = jest.genMockFunction();
+      const originalConfirm = window.confirm;
 
-      bulkActions.getOptionByValue.mockReturnValueOnce({destructive: true});
+      bulkActions.getOptionByValue.mockReturnValueOnce({ destructive: true });
       mock.mockReturnValueOnce(true);
       window.confirm = mock;
       i18n.sprintf = jest.genMockFunction();
@@ -131,8 +131,8 @@ describe('BulkActionsComponent', () => {
       window.confirm = originalConfirm;
     });
 
-    it('should not ask user for confirmation if the action is not destructive', function () {
-      bulkActions.getOptionByValue.mockReturnValueOnce({destructive: false});
+    it('should not ask user for confirmation if the action is not destructive', () => {
+      bulkActions.getOptionByValue.mockReturnValueOnce({ destructive: false });
 
       bulkActions.onChangeValue(event);
 

--- a/javascript/src/components/dropzone/tests/dropzone-component-test.js
+++ b/javascript/src/components/dropzone/tests/dropzone-component-test.js
@@ -1,100 +1,98 @@
+/* global jest, jasmine, describe, it, expect, beforeEach */
+
 jest.dontMock('../index.js');
 jest.dontMock('dropzone');
 
-const React = require('react'),
-    ReactDOM = require('react-dom'),
-    i18n = require('i18n'),
-    ReactTestUtils = require('react-addons-test-utils'),
-    DropzoneComponent = require('../index.js');
+const React = require('react');
+const ReactTestUtils = require('react-addons-test-utils');
+const DropzoneComponent = require('../index.js');
 
 describe('DropzoneComponent', () => {
+  let props;
 
-    var props;
+  beforeEach(() => {
+    props = {
+      options: {
+        url: 'upload',
+      },
+      handleAddedFile: () => null,
+      handleError: () => null,
+      handleSuccess: () => null,
+      folderID: 1,
+      securityID: '123',
+    };
+  });
+
+  describe('constructor()', () => {
+    let Dropzone;
 
     beforeEach(() => {
-        props = {
-            options: {
-                url: 'upload'
-            },
-            handleAddedFile: () => null,
-            handleError: () => null,
-            handleSuccess: () => null,
-            folderID: 1,
-            securityID: '123'
-        }
+      Dropzone = ReactTestUtils.renderIntoDocument(
+        <DropzoneComponent {...props} />
+      );
     });
 
-    describe('constructor()', () => {
-        var Dropzone;
+    it('should set this.dropzone to null', () => {
+      Dropzone.dropzone = 1;
+      Dropzone.constructor(props);
 
-        beforeEach(function () {
-            Dropzone = ReactTestUtils.renderIntoDocument(
-                <DropzoneComponent {...props} />
-            );
-        });
-
-        it('should set this.dropzone to null', () => {
-            Dropzone.dropzone = 1;
-            Dropzone.constructor(props);
-
-            expect(Dropzone.dropzone).toBe(null);
-        });
+      expect(Dropzone.dropzone).toBe(null);
     });
-    
-    describe('componentDidMount()', () => {
-        var Dropzone;
+  });
 
-        beforeEach(() => {
-            props.promptOnRemove = 'prompt';
+  describe('componentDidMount()', () => {
+    let Dropzone;
 
-            Dropzone = ReactTestUtils.renderIntoDocument(
-                <DropzoneComponent {...props} />
-            );
-        });
+    beforeEach(() => {
+      props.promptOnRemove = 'prompt';
 
-        it('should set this.dropzone to a new Dropzone', () => {
-            expect(Dropzone.dropzone.options.url).toBe('upload');
-        });
-        
-        it('should call setPromptOnRemove if props.promptOnRemove is set', () => {
-            expect(Dropzone.dropzone.options.dictRemoveFileConfirmation).toBe('prompt');
-        });
+      Dropzone = ReactTestUtils.renderIntoDocument(
+        <DropzoneComponent {...props} />
+      );
     });
 
-    describe('componentWillUnmount()', () => {
-        var Dropzone;
-
-        beforeEach(() => {
-            Dropzone = ReactTestUtils.renderIntoDocument(
-                <DropzoneComponent {...props} />
-            );
-        });
-        
-        it('should remove all dropzone listeners', () => {
-            Dropzone.dropzone.disable = jest.genMockFunction();
-            Dropzone.componentWillUnmount();
-            
-            expect(Dropzone.dropzone.disable).toBeCalled();
-            
-        });
+    it('should set this.dropzone to a new Dropzone', () => {
+      expect(Dropzone.dropzone.options.url).toBe('upload');
     });
 
-    describe('handleAddedFile()', () => {
+    it('should call setPromptOnRemove if props.promptOnRemove is set', () => {
+      expect(Dropzone.dropzone.options.dictRemoveFileConfirmation).toBe('prompt');
+    });
+  });
+
+  describe('componentWillUnmount()', () => {
+    let Dropzone;
+
+    beforeEach(() => {
+      Dropzone = ReactTestUtils.renderIntoDocument(
+        <DropzoneComponent {...props} />
+      );
     });
 
-    describe('setPromptOnRemove()', () => {
-        var Dropzone;
+    it('should remove all dropzone listeners', () => {
+      Dropzone.dropzone.disable = jest.genMockFunction();
+      Dropzone.componentWillUnmount();
 
-        beforeEach(() => {
-            Dropzone = ReactTestUtils.renderIntoDocument(
-                <DropzoneComponent {...props} />
-            );
-        });
-        
-        it('should set dropzone.options.dictRemoveFileConfirmation to the given string', () => {
-            Dropzone.setPromptOnRemove('prompt');
-            
-            expect(Dropzone.dropzone.options.dictRemoveFileConfirmation).toBe('prompt')
-        });
+      expect(Dropzone.dropzone.disable).toBeCalled();
     });
+  });
+
+  describe('handleAddedFile()', () => {
+  });
+
+  describe('setPromptOnRemove()', () => {
+    let Dropzone;
+
+    beforeEach(() => {
+      Dropzone = ReactTestUtils.renderIntoDocument(
+        <DropzoneComponent {...props} />
+      );
+    });
+
+    it('should set dropzone.options.dictRemoveFileConfirmation to the given string', () => {
+      Dropzone.setPromptOnRemove('prompt');
+
+      expect(Dropzone.dropzone.options.dictRemoveFileConfirmation).toBe('prompt');
+    });
+  });
 });

--- a/javascript/src/components/file/tests/file-component-test.js
+++ b/javascript/src/components/file/tests/file-component-test.js
@@ -1,255 +1,257 @@
+/* global jest, jasmine, describe, it, expect, beforeEach */
+
 jest.dontMock('../index.js');
 
-const React = require('react'),
-    $ = require('jQuery'),
-    ReactDom = require('react-dom'),
-    i18n = require('i18n'),
-    ReactTestUtils = require('react-addons-test-utils'),
-    FileComponent = require('../index.js');
+const React = require('react');
+const ReactTestUtils = require('react-addons-test-utils');
+const FileComponent = require('../index.js');
 
-describe('FileComponent', function() {
-    
-    var props;
+describe('FileComponent', () => {
+  let props;
 
-    beforeEach(function () {
-        props = {
-            id: 0,
-            selected: false,
-            handleToggleSelect: jest.genMockFunction(),
-            handleActivate: jest.genMockFunction(),
-            handleDelete: jest.genMockFunction(),
-            item: {
-                attributes: {
-                    dimensions: {
-                        width: 10,
-                        height: 10
-                    }
-                },
-                category: 'image',
-                id: 1,
-                title: 'test'
-            }
-        }
+  beforeEach(() => {
+    props = {
+      id: 0,
+      selected: false,
+      handleToggleSelect: jest.genMockFunction(),
+      handleActivate: jest.genMockFunction(),
+      handleDelete: jest.genMockFunction(),
+      item: {
+        attributes: {
+          dimensions: {
+            width: 10,
+            height: 10,
+          },
+        },
+        category: 'image',
+        id: 1,
+        title: 'test',
+      },
+    };
   });
 
-    describe('handleActivate()', function () {
-        var file, event;
-        
-        beforeEach(function () {
-            file = ReactTestUtils.renderIntoDocument(
-                <FileComponent {...props} />
-            );
+  describe('handleActivate()', () => {
+    let file;
+    let event;
 
-            event = {
-                stopPropagation: jest.genMockFunction()
-            }
-        });
-        
-        it('should call props.handleActivate', function () {
-            expect(file.props.handleActivate.mock.calls.length).toBe(0);
-            
-            file.handleActivate(event);
-            
-            expect(file.props.handleActivate).toBeCalled();
-        });
-        
-        it('should stop propagation of the event', function () {
-            file.handleActivate(event);
-            
-            expect(event.stopPropagation).toBeCalled();
-        });
-    });
-    
-    describe('handleToggleSelect()', function () {
-        var file, event;
-        
-        beforeEach(function () {
-            file = ReactTestUtils.renderIntoDocument(
-                <FileComponent {...props} />
-            );
+    beforeEach(() => {
+      file = ReactTestUtils.renderIntoDocument(
+        <FileComponent {...props} />
+      );
 
-            event = {
-                stopPropagation: jest.genMockFunction()
-            }
-        });
-        
-        it('should call props.handleToggleSelect', function () {
-            expect(file.props.handleToggleSelect.mock.calls.length).toBe(0);
-            
-            file.handleToggleSelect(event);
-            
-            expect(file.props.handleToggleSelect).toBeCalled();
-        });
-        
-        it('should stop propagation of the event', function () {
-            file.handleToggleSelect(event);
-            
-            expect(event.stopPropagation).toBeCalled();
-        });
-    });
-    
-    describe('getThumbnailStyles()', function () {
-        var file;
-        
-        beforeEach(function () {
-            props.item.url = 'myurl';
-            
-            file = ReactTestUtils.renderIntoDocument(
-                <FileComponent {...props} />
-            );
-        });
-        
-        it('should return backgroundImage with the correct url if the item is an image', function () {
-            file.props.item.category = 'image';
-
-            expect(JSON.stringify(file.getThumbnailStyles())).toBe('{"backgroundImage":"url(myurl)"}');
-        });
-
-        it('should return an empty object if the item is not an image', function () {
-            file.props.item.category = 'notAnImage';
-            
-            expect(JSON.stringify(file.getThumbnailStyles())).toBe('{}');
-        });
-    });
-    
-    describe('getThumbnailClassNames()', function () {
-        var file;
-
-        beforeEach(function () {
-            file = ReactTestUtils.renderIntoDocument(
-                <FileComponent {...props} />
-            );
-            
-            file.isImageSmallerThanThumbnail = jest.genMockFunction();
-        });
-
-        it('should return "item__thumbnail"', function () {
-            expect(file.getThumbnailClassNames()).toBe('item__thumbnail');
-        });
-
-        it('should return "item__thumbnail item__thumbnail--small" if isImageSmallerThanThumbnail returns true', function () {
-            file.isImageSmallerThanThumbnail.mockReturnValueOnce(true);
-
-            expect(file.getThumbnailClassNames()).toContain('item__thumbnail--small');
-        });
+      event = {
+        stopPropagation: jest.genMockFunction(),
+      };
     });
 
-    describe('getItemClassNames()', function () {
-        var file;
-        
-        it('should return the file\'s category', function () {
-            props.item.category = 'image';
+    it('should call props.handleActivate', () => {
+      expect(file.props.handleActivate.mock.calls.length).toBe(0);
 
-            file = ReactTestUtils.renderIntoDocument(
-                <FileComponent {...props} />
-            );
+      file.handleActivate(event);
 
-            expect(file.getItemClassNames()).toContain('item--image');
-        });
-        
-        it('should return selected if the selected prop is true', function () {
-            props.selected = true;
-
-            file = ReactTestUtils.renderIntoDocument(
-                <FileComponent {...props} />
-            );
-
-            expect(file.getItemClassNames()).toContain('item--selected');
-        });
+      expect(file.props.handleActivate).toBeCalled();
     });
 
-    describe('isImageSmallerThanThumbnail()', function () {
-        var file;
-        
-        beforeEach(function () {
-            file = ReactTestUtils.renderIntoDocument(
-                <FileComponent {...props} />
-            );
-        });
-        
-        it('should return true if the dimensions are smaller than the default thumbnail size', function () {
-            expect(file.isImageSmallerThanThumbnail()).toBe(true);
-        });
-        
-        it('should return false if the dimensions are larger than the default thumbnail size', function () {
-            props.item.attributes.dimensions = {
-                width: 1000,
-                height: 1000
-            }
+    it('should stop propagation of the event', () => {
+      file.handleActivate(event);
 
-            expect(file.isImageSmallerThanThumbnail()).toBe(false);
-        });
+      expect(event.stopPropagation).toBeCalled();
+    });
+  });
+
+  describe('handleToggleSelect()', () => {
+    let file;
+    let event;
+
+    beforeEach(() => {
+      file = ReactTestUtils.renderIntoDocument(
+        <FileComponent {...props} />
+      );
+
+      event = {
+        stopPropagation: jest.genMockFunction(),
+      };
     });
 
-    describe('handleKeyDown()', function () {
-        var file, event; 
-        
-        beforeEach(function () {
-            props.spaceKey = 32;
-            props.returnKey = 13;
+    it('should call props.handleToggleSelect', () => {
+      expect(file.props.handleToggleSelect.mock.calls.length).toBe(0);
 
-            file = ReactTestUtils.renderIntoDocument(
-                <FileComponent {...props} />
-            );
-            
-            event = {
-                stopPropagation: jest.genMockFunction(),
-                preventDefault: jest.genMockFunction()
-            }
-            
-            file.handleToggleSelect = jest.genMockFunction();
-            file.handleActivate = jest.genMockFunction();
-        });
-        
-        it('should trigger handleToggleSelect when the space key is pressed', function () {
-            event.keyCode = 32;
-            expect(file.handleToggleSelect.mock.calls.length).toBe(0);
+      file.handleToggleSelect(event);
 
-            file.handleKeyDown(event);
-
-            expect(file.handleToggleSelect).toBeCalled();
-        });
-        
-        it('should trigger handleActivate when the return key is pressed', function () {
-            event.keyCode = 13;
-            expect(file.handleActivate.mock.calls.length).toBe(0);
-
-            file.handleKeyDown(event);
-
-            expect(file.handleActivate).toBeCalled();
-        });
-        
-        it('should stop propagation of the event', function () {
-            file.handleKeyDown(event);
-            
-            expect(event.stopPropagation).toBeCalled();
-        });
-        
-        it('should prevent the default behaviour of the event', function () {
-            event.keyCode = 32;
-            file.handleKeyDown(event);
-            
-            expect(event.preventDefault).toBeCalled();
-        });
+      expect(file.props.handleToggleSelect).toBeCalled();
     });
-    
-    describe('preventFocus()', function () {
-        var file, event;
-        
-        beforeEach(function () {
-            file = ReactTestUtils.renderIntoDocument(
-                <FileComponent {...props} />
-            );
-            
-            event = {
-                preventDefault: jest.genMockFunction()
-            }
-        });
-        
-        it('should prevent the default behaviour of the event', function () {
-            file.preventFocus(event);
-            
-            expect(event.preventDefault).toBeCalled();
-        });
+
+    it('should stop propagation of the event', () => {
+      file.handleToggleSelect(event);
+
+      expect(event.stopPropagation).toBeCalled();
     });
+  });
+
+  describe('getThumbnailStyles()', () => {
+    let file;
+
+    beforeEach(() => {
+      props.item.url = 'myurl';
+
+      file = ReactTestUtils.renderIntoDocument(
+        <FileComponent {...props} />
+      );
+    });
+
+    it('should return backgroundImage with the correct url if the item is an image', () => {
+      file.props.item.category = 'image';
+
+      expect(JSON.stringify(file.getThumbnailStyles())).toBe('{"backgroundImage":"url(myurl)"}');
+    });
+
+    it('should return an empty object if the item is not an image', () => {
+      file.props.item.category = 'notAnImage';
+
+      expect(JSON.stringify(file.getThumbnailStyles())).toBe('{}');
+    });
+  });
+
+  describe('getThumbnailClassNames()', () => {
+    let file;
+
+    beforeEach(() => {
+      file = ReactTestUtils.renderIntoDocument(
+        <FileComponent {...props} />
+      );
+
+      file.isImageSmallerThanThumbnail = jest.genMockFunction();
+    });
+
+    it('should return "item__thumbnail"', () => {
+      expect(file.getThumbnailClassNames()).toBe('item__thumbnail');
+    });
+
+    it('should return "item__thumbnail item__thumbnail--small" if isImageSmallerThanThumbnail returns true', () => {
+      file.isImageSmallerThanThumbnail.mockReturnValueOnce(true);
+
+      expect(file.getThumbnailClassNames()).toContain('item__thumbnail--small');
+    });
+  });
+
+  describe('getItemClassNames()', () => {
+    let file;
+
+    it('should return the file\'s category', () => {
+      props.item.category = 'image';
+
+      file = ReactTestUtils.renderIntoDocument(
+        <FileComponent {...props} />
+      );
+
+      expect(file.getItemClassNames()).toContain('item--image');
+    });
+
+    it('should return selected if the selected prop is true', () => {
+      props.selected = true;
+
+      file = ReactTestUtils.renderIntoDocument(
+        <FileComponent {...props} />
+      );
+
+      expect(file.getItemClassNames()).toContain('item--selected');
+    });
+  });
+
+  describe('isImageSmallerThanThumbnail()', () => {
+    let file;
+
+    beforeEach(() => {
+      file = ReactTestUtils.renderIntoDocument(
+        <FileComponent {...props} />
+      );
+    });
+
+    it('should return true if the dimensions are smaller than the default thumbnail size', () => {
+      expect(file.isImageSmallerThanThumbnail()).toBe(true);
+    });
+
+    it('should return false if the dimensions are larger than the default thumbnail size', () => {
+      props.item.attributes.dimensions = {
+        width: 1000,
+        height: 1000,
+      };
+
+      expect(file.isImageSmallerThanThumbnail()).toBe(false);
+    });
+  });
+
+  describe('handleKeyDown()', () => {
+    let file;
+    let event;
+
+    beforeEach(() => {
+      props.spaceKey = 32;
+      props.returnKey = 13;
+
+      file = ReactTestUtils.renderIntoDocument(
+        <FileComponent {...props} />
+      );
+
+      event = {
+        stopPropagation: jest.genMockFunction(),
+        preventDefault: jest.genMockFunction(),
+      };
+
+      file.handleToggleSelect = jest.genMockFunction();
+      file.handleActivate = jest.genMockFunction();
+    });
+
+    it('should trigger handleToggleSelect when the space key is pressed', () => {
+      event.keyCode = 32;
+      expect(file.handleToggleSelect.mock.calls.length).toBe(0);
+
+      file.handleKeyDown(event);
+
+      expect(file.handleToggleSelect).toBeCalled();
+    });
+
+    it('should trigger handleActivate when the return key is pressed', () => {
+      event.keyCode = 13;
+      expect(file.handleActivate.mock.calls.length).toBe(0);
+
+      file.handleKeyDown(event);
+
+      expect(file.handleActivate).toBeCalled();
+    });
+
+    it('should stop propagation of the event', () => {
+      file.handleKeyDown(event);
+
+      expect(event.stopPropagation).toBeCalled();
+    });
+
+    it('should prevent the default behaviour of the event', () => {
+      event.keyCode = 32;
+      file.handleKeyDown(event);
+
+      expect(event.preventDefault).toBeCalled();
+    });
+  });
+
+  describe('preventFocus()', () => {
+    let file;
+    let event;
+
+    beforeEach(() => {
+      file = ReactTestUtils.renderIntoDocument(
+        <FileComponent {...props} />
+      );
+
+      event = {
+        preventDefault: jest.genMockFunction(),
+      };
+    });
+
+    it('should prevent the default behaviour of the event', () => {
+      file.preventFocus(event);
+
+      expect(event.preventDefault).toBeCalled();
+    });
+  });
 });

--- a/javascript/src/state/queued-files/tests/queued-files-test.js
+++ b/javascript/src/state/queued-files/tests/queued-files-test.js
@@ -1,129 +1,135 @@
+/* global jest, jasmine, describe, it, expect, beforeEach */
+
 jest.dontMock('deep-freeze');
 jest.dontMock('../action-types');
 jest.dontMock('../reducer');
 
-var queuedFilesReducer = require('../reducer');
+const queuedFilesReducer = require('../reducer');
 
 describe('queuedFilesReducer', () => {
+  describe('PURGE_UPLOAD_QUEUE', () => {
+    const action = { type: 'PURGE_UPLOAD_QUEUE', payload: null };
 
-    describe('PURGE_UPLOAD_QUEUE', () => {
-        const action = { type: 'PURGE_UPLOAD_QUEUE', payload: null };
+    it('should remove failed uploads from the queue', () => {
+      const initialState = {
+        items: [
+          {
+            id: 0,
+            messages: [{
+              value: 'Failed to upload file',
+              type: 'error',
+              extraClass: 'error',
+            }],
+          },
+          {
+            id: 1,
+            messages: [{
+              value: 'Uploading...',
+              type: 'pending',
+              extraClass: 'pending',
+            }],
+          },
+        ],
+      };
 
-        it('should remove failed uploads from the queue', () => {
-            const initialState = {
-                items: [{
-                    id: 0,
-                    messages: [{
-                        value: 'Failed to upload file',
-                        type: 'error',
-                        extraClass: 'error'
-                    }]
-                },
-                {
-                    id: 1,
-                    messages: [{
-                        value: 'Uploading...',
-                        type: 'pending',
-                        extraClass: 'pending'
-                    }]
-                }]
-            };
+      const nextState = queuedFilesReducer(initialState, action);
 
-            const nextState = queuedFilesReducer(initialState, action);
-
-            expect(nextState.items.length).toBe(1);
-        });
-
-        it('should move successful uploads from the queue', () => {
-            const initialState = {
-                items: [{
-                    id: 0,
-                    messages: [{
-                        value: 'File uploaded',
-                        type: 'success',
-                        extraClass: 'success'
-                    }]
-                },
-                {
-                    id: 1,
-                    messages: [{
-                        value: 'Uploading...',
-                        type: 'pending',
-                        extraClass: 'pending'
-                    }]
-                }]
-            };
-
-            const nextState = queuedFilesReducer(initialState, action);
-
-            expect(nextState.items.length).toBe(1);
-        });
-
-        it('should ignore pending uploads', () => {
-            const initialState = {
-                items: [{
-                    id: 0,
-                    messages: [{
-                        value: 'Uploading...',
-                        type: 'pending',
-                        extraClass: 'pending'
-                    }]
-                },
-                {
-                    id: 1,
-                    messages: [{
-                        value: 'Uploading...',
-                        type: 'pending',
-                        extraClass: 'pending'
-                    }]
-                }]
-            };
-
-            const nextState = queuedFilesReducer(initialState, action);
-
-            expect(nextState.items.length).toBe(2);
-        });
+      expect(nextState.items.length).toBe(1);
     });
 
-    describe('FAIL_UPLOAD', () => {
-        const type = 'FAIL_UPLOAD';
-        const initialState = {
-            items: [{
-                filename: 'unclepaul.png',
-                size: 123
-            }]
-        };
+    it('should move successful uploads from the queue', () => {
+      const initialState = {
+        items: [
+          {
+            id: 0,
+            messages: [{
+              value: 'File uploaded',
+              type: 'success',
+              extraClass: 'success',
+            }],
+          },
+          {
+            id: 1,
+            messages: [{
+              value: 'Uploading...',
+              type: 'pending',
+              extraClass: 'pending',
+            }],
+          },
+        ],
+      };
 
-        it('should set an error message on the file', () => {
-            const nextState = queuedFilesReducer(initialState, {
-                type,
-                payload: {
-                    file: {
-                        name: 'unclepaul.png',
-                        size: 123
-                    }
-                }
-            });
+      const nextState = queuedFilesReducer(initialState, action);
 
-            expect(nextState.items[0].messages.length).toBe(1);
-        });
+      expect(nextState.items.length).toBe(1);
     });
 
-    describe('REMOVE_QUEUED_FILE', () => {
-        const type = 'REMOVE_QUEUED_FILE';
-        const initialState = {
-            items: [{ queuedAtTime: 123 }, { queuedAtTime: 456 }]
-        };
+    it('should ignore pending uploads', () => {
+      const initialState = {
+        items: [
+          {
+            id: 0,
+            messages: [{
+              value: 'Uploading...',
+              type: 'pending',
+              extraClass: 'pending',
+            }],
+          },
+          {
+            id: 1,
+            messages: [{
+              value: 'Uploading...',
+              type: 'pending',
+              extraClass: 'pending',
+            }],
+          },
+        ],
+      };
 
-        it('should remove the file from the queue', () => {
-            const nextState = queuedFilesReducer(initialState, {
-                type,
-                payload: { queuedAtTime: 456 }
-            });
+      const nextState = queuedFilesReducer(initialState, action);
 
-            expect(nextState.items.length).toBe(1);
-            expect(nextState.items[0].queuedAtTime).toBe(123);
-        });
+      expect(nextState.items.length).toBe(2);
     });
+  });
 
+  describe('FAIL_UPLOAD', () => {
+    const type = 'FAIL_UPLOAD';
+    const initialState = {
+      items: [{
+        filename: 'unclepaul.png',
+        size: 123,
+      }],
+    };
+
+    it('should set an error message on the file', () => {
+      const nextState = queuedFilesReducer(initialState, {
+        type,
+        payload: {
+          file: {
+            name: 'unclepaul.png',
+            size: 123,
+          },
+        },
+      });
+
+      expect(nextState.items[0].messages.length).toBe(1);
+    });
+  });
+
+  describe('REMOVE_QUEUED_FILE', () => {
+    const type = 'REMOVE_QUEUED_FILE';
+    const initialState = {
+      items: [{ queuedAtTime: 123 }, { queuedAtTime: 456 }],
+    };
+
+    it('should remove the file from the queue', () => {
+      const nextState = queuedFilesReducer(initialState, {
+        type,
+        payload: { queuedAtTime: 456 },
+      });
+
+      expect(nextState.items.length).toBe(1);
+      expect(nextState.items[0].queuedAtTime).toBe(123);
+    });
+  });
 });

--- a/javascript/src/state/schema/tests/reducer-test.js
+++ b/javascript/src/state/schema/tests/reducer-test.js
@@ -1,72 +1,72 @@
+/* global jest, jasmine, describe, it, expect, beforeEach */
+
 jest.dontMock('deep-freeze');
 jest.dontMock('../action-types.js');
 jest.dontMock('../reducer.js');
 
-var schemaReducer = require('../reducer.js');
-var ACTION_TYPES = require('../action-types');
+const schemaReducer = require('../reducer.js');
+const ACTION_TYPES = require('../action-types');
 
 describe('schemaReducer', () => {
+  describe('SET_SCHEMA', () => {
+    it('should create a new form when none exist', () => {
+      const initialState = { forms: [] };
+      const serverResponse = { id: 'TestForm' };
 
-    describe('SET_SCHEMA', () => {
+      const nextState = schemaReducer(initialState, {
+        type: ACTION_TYPES.SET_SCHEMA,
+        payload: { schema: serverResponse },
+      });
 
-        it('should create a new form when none exist', () => {
-            const initialState = { forms: [] };
-            const serverResponse = { id : 'TestForm' };
-
-            const nextState = schemaReducer(initialState, { 
-                type: ACTION_TYPES.SET_SCHEMA,
-                payload: { schema: serverResponse }
-            });
-
-            expect(nextState.forms.length).toBe(1);
-            expect(JSON.stringify(nextState.forms[0])).toBe(JSON.stringify({ schema: { id: 'TestForm' } }));
-        });
-
-        it('should update an existing form', () => {
-            const initialState = {
-                forms: [{
-                    schema: {
-                        id: 'TestForm',
-                        name: 'TestForm'
-                    }
-                }]
-            };
-
-            const serverResponse = { id: 'TestForm', name: 'BetterTestForm' };
-
-            const nextState = schemaReducer(initialState, { 
-                type: ACTION_TYPES.SET_SCHEMA,
-                payload: { schema: serverResponse }
-            });
-
-            expect(nextState.forms.length).toBe(1);
-            expect(JSON.stringify(nextState.forms[0])).toBe(JSON.stringify({ schema: { id: 'TestForm', name: 'BetterTestForm' } }));
-        });
-
-        it("should only update the the form's 'schema' key", () => {
-            const initialState = {
-                forms: [{
-                    schema: {
-                        id: 'TestForm',
-                        name: 'TestForm'
-                    },
-                    state: {
-                        error: 'Oops!'
-                    }
-                }]
-            };
-
-            const serverResponse = { id: 'TestForm', name: 'BetterTestForm' };
-
-            const nextState = schemaReducer(initialState, { 
-                type: ACTION_TYPES.SET_SCHEMA,
-                payload: { schema: serverResponse }
-            });
-
-            expect(nextState.forms.length).toBe(1);
-            expect(JSON.stringify(nextState.forms[0])).toBe(JSON.stringify({ schema: { id: 'TestForm', name: 'BetterTestForm' }, state: { error: 'Oops!' } }));
-        });
-
+      expect(nextState.forms.length).toBe(1);
+      expect(JSON.stringify(nextState.forms[0])).toBe(JSON.stringify({ schema: { id: 'TestForm' } }));
     });
 
+    it('should update an existing form', () => {
+      const initialState = {
+        forms: [{
+          schema: {
+            id: 'TestForm',
+            name: 'TestForm',
+          },
+        }],
+      };
+
+      const serverResponse = { id: 'TestForm', name: 'BetterTestForm' };
+
+      const nextState = schemaReducer(initialState, {
+        type: ACTION_TYPES.SET_SCHEMA,
+        payload: { schema: serverResponse },
+      });
+
+      expect(nextState.forms.length).toBe(1);
+      expect(JSON.stringify(nextState.forms[0]))
+        .toBe(JSON.stringify({ schema: { id: 'TestForm', name: 'BetterTestForm' } }));
+    });
+
+    it("should only update the the form's 'schema' key", () => {
+      const initialState = {
+        forms: [{
+          schema: {
+            id: 'TestForm',
+            name: 'TestForm',
+          },
+          state: {
+            error: 'Oops!',
+          },
+        }],
+      };
+
+      const serverResponse = { id: 'TestForm', name: 'BetterTestForm' };
+
+      const nextState = schemaReducer(initialState, {
+        type: ACTION_TYPES.SET_SCHEMA,
+        payload: { schema: serverResponse },
+      });
+
+      expect(nextState.forms.length).toBe(1);
+      expect(JSON.stringify(nextState.forms[0]))
+        .toBe(JSON.stringify({ schema: { id: 'TestForm', name: 'BetterTestForm' }, state: { error: 'Oops!' } }));
+    });
+  });
 });


### PR DESCRIPTION
Remove test files from .eslintignore, and correct the listing errors
present in them. Helps to ensure that our tests follow the style guides.

I also cleaned up AssetAdmin.js, for completeness.