### PR TITLE
NEW: Add scss listing with the sass-lint package.

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,0 +1,58 @@
+# Generated with http://sasstools.github.io/make-sass-lint-config/
+# Based on https://github.com/airbnb/css/blob/master/.scss-lint.yml
+
+files:
+  include: 'javascript/**/*.s+(a|c)ss'
+options:
+  formatter: stylish
+  merge-default-rules: false
+rules:
+  indent:
+    - 2
+    - spaces: 2
+  bem-depth: 2
+  border-zero:
+    - 2
+    - convention: "0"
+  brace-style:
+    - 2
+    - allow-single-line: false
+  class-name-format:
+    - 2
+    - convention: '^(?!js-).*'
+      convention-explanation: 'should not be written in the form js-*'
+  extends-before-declarations: 0
+  extends-before-mixins: 0
+  function-name-format: 2
+  leading-zero: 0
+  mixin-name-format: 2
+  mixins-before-declarations: 0
+  no-extends: 2
+  no-qualifying-elements: 0
+  placeholder-name-format:
+    - 2
+    - convention: hyphenatedbem
+  property-sort-order: 0
+  quotes:
+    - 2
+    - style: double
+  variable-name-format: 2
+  space-after-colon: 2
+  space-after-comma: 2
+  space-around-operator: 2
+  space-before-brace: 2
+  no-css-comments: 2
+  zero-unit: 2
+  no-color-keywords: 2
+  no-color-literals: 2
+  final-newline: 2
+  no-empty-rulesets: 2
+  url-quotes: 2
+  nesting-depth:
+    - 2
+    - depth: 3
+  no-duplicate-properties: 2
+  trailing-semicolon: 2
+  hex-notation:
+    - 2
+    - style: "lowercase"

--- a/javascript/src/components/bulk-actions/styles.scss
+++ b/javascript/src/components/bulk-actions/styles.scss
@@ -1,129 +1,127 @@
 .gallery__bulk-actions {
-    padding: 10px 12px;
-    left: 160px; /* TODO: Needs to go to 60px when main nav is collapsed */
-    z-index: 59;
-    right: 0;
-    height: 52px;
-    margin: 0 auto;
-    position: fixed;
+  padding: 10px 12px;
+  left: 160px; /* TODO: Needs to go to 60px when main nav is collapsed */
+  z-index: 59;
+  right: 0;
+  height: 52px;
+  margin: 0 auto;
+  position: fixed;
+  top: 52px;
+  width: 200px;
+  box-shadow : 0px 1px 2px rgba(0, 0, 0, 0.2);
+  background-color: $body-bg-dark;
+  transition: all 0.5s ease-in-out;
+  transform: scale(1);
+
+  &-enter {
+    top: 0;
+    transform: scale(.95);
+  }
+
+  &-enter-active {
     top: 52px;
-    width: 200px;
-    box-shadow : 0px 1px 2px rgba(0, 0, 0, 0.2);
-    background-color: $body-bg-dark;
-    transition: all 0.5s ease-in-out;
     transform: scale(1);
+    transition: top .2s linear, transform .1s ease-in .2s;
+  }
 
-    &-enter {
-        top: 0;
-        transform: scale(.95);
+  &-leave {
+    top: 52px;
+    transform: scale(1);
+  }
+
+  &-leave-active {
+    top: 0;
+    transform: scale(.95);
+    transition: top .2s linear .1s, transform .1s ease-in;
+  }
+
+  .gallery__bulk-actions__counter {
+    display: inline-block;
+    min-width: 28px;
+    padding: 6px;
+    margin: 2px 8px 2px 0;
+    line-height: 16px;
+    color: white;
+    text-align: center;
+    background-color: $state-active;
+    border-radius: 4px;
+    font-weight: bold;
+  }
+
+  .gallery__bulk-actions_action.ss-ui-button {
+    line-height: $line-height;
+    margin-bottom: 0;
+    height: 32px;
+
+    &[class*="font-icon-"]::before {
+      font-size: 20px;
+      line-height: 18px;
+      position: relative;
+      top: -1px;
     }
-    
-    &-enter-active {
-        top: 52px;
-        transform: scale(1);
-        transition: top .2s linear,
-                    transform .1s ease-in .2s;
-    }
-    
-    &-leave {
-        top: 52px;
-        transform: scale(1);
-    }
-    
-    &-leave-active {
-        top: 0;
-        transform: scale(.95);
-        transition: top .2s linear .1s,
-                    transform .1s ease-in;
-    }
+  }
 
-    .gallery__bulk-actions__counter {
-        display: inline-block;
-        min-width: 28px;
-        padding: 6px;
-        margin: 2px 8px 2px 0;
-        line-height: 16px;
-        color: white;
-        text-align: center;
-        background-color: $state-active;
-        border-radius: 4px;
-        font-weight: bold;
-    }
-    
-    .gallery__bulk-actions_action.ss-ui-button {
-        line-height: $line-height;
-        margin-bottom: 0;
-        height: 32px;
+  .chzn-single {
+    border-radius: 5px 0 0 5px;
+    border: 0;
+    filter: none; //IE9
+    background: none;
+    box-shadow: none;
+    color: inherit;
 
-        &[class*="font-icon-"]::before {
-            font-size: 20px;
-            line-height: 18px;
-            position: relative;
-            top: -1px;
-        }
-    }
-
-    .chzn-single {
-        border-radius: 5px 0 0 5px;
-        border: 0;
-        filter: none; //IE9
-        background: none;
-        box-shadow: none;
-        color: inherit;
-
-        &:focus {
-            box-shadow: 0 0 3px 0 rgba(0,0,0,.2);
-        }
-
-        > span {
-            text-align: left;
-            display: inline-block;
-            margin-right: 0;
-        }
-
-        > div {
-            position: static;
-            display: inline-block;
-        }
+    &:focus {
+      box-shadow: 0 0 3px 0 rgba(0,0,0,.2);
     }
 
-    .chzn-drop {
-        border-radius: 3px;
-        box-shadow: 0 0 3px rgba(0,0,0,.2);
-        border: 0;
+    > span {
+      text-align: left;
+      display: inline-block;
+      margin-right: 0;
     }
 
-    .search-choice-close {
-        display: none;
+    > div {
+      position: static;
+      display: inline-block;
+    }
+  }
+
+  .chzn-drop {
+    border-radius: 3px;
+    box-shadow: 0 0 3px rgba(0,0,0,.2);
+    border: 0;
+  }
+
+  .search-choice-close {
+    display: none;
+  }
+
+  .chzn-results li {
+    padding-left: 22px;
+    position: relative;
+
+    &::before {
+      position: absolute;
+      font-family: silverstripe;
+      left: 4px;
+      font-size: 14px;
+      vertical-align: middle;
+      margin-right: 4px;
     }
 
-    .chzn-results li {
-        padding-left: 22px;
-        position: relative;
-
-        &::before {
-            position: absolute;
-            font-family: silverstripe;
-            left: 4px;
-            font-size: 14px;
-            vertical-align: middle;
-            margin-right: 4px;
-        }
-
-        &:nth-child(1)::before {
-            content: 'g';
-        }
-
-        &:nth-child(2)::before {
-
-        }
-
-        &:nth-child(3)::before {
-
-        }
-
-        &:nth-child(4)::before {
-
-        }
+    &:nth-child(1)::before {
+      content: 'g';
     }
+
+    &:nth-child(2)::before {
+
+    }
+
+    &:nth-child(3)::before {
+
+    }
+
+    &:nth-child(4)::before {
+
+    }
+  }
 }

--- a/javascript/src/components/bulk-actions/styles.scss
+++ b/javascript/src/components/bulk-actions/styles.scss
@@ -1,6 +1,6 @@
 .gallery__bulk-actions {
   padding: 10px 12px;
-  left: 160px; /* TODO: Needs to go to 60px when main nav is collapsed */
+  left: 160px; // TODO: Needs to go to 60px when main nav is collapsed
   z-index: 59;
   right: 0;
   height: 52px;
@@ -8,7 +8,7 @@
   position: fixed;
   top: 52px;
   width: 200px;
-  box-shadow : 0px 1px 2px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 1px 2px $shadow-black;
   background-color: $body-bg-dark;
   transition: all 0.5s ease-in-out;
   transform: scale(1);
@@ -41,7 +41,7 @@
     padding: 6px;
     margin: 2px 8px 2px 0;
     line-height: 16px;
-    color: white;
+    color: $state-active-text;
     text-align: center;
     background-color: $state-active;
     border-radius: 4px;
@@ -70,7 +70,7 @@
     color: inherit;
 
     &:focus {
-      box-shadow: 0 0 3px 0 rgba(0,0,0,.2);
+      box-shadow: 0 0 3px 0 $shadow-black;
     }
 
     > span {
@@ -87,7 +87,7 @@
 
   .chzn-drop {
     border-radius: 3px;
-    box-shadow: 0 0 3px rgba(0,0,0,.2);
+    box-shadow: 0 0 3px $shadow-black;
     border: 0;
   }
 
@@ -109,19 +109,7 @@
     }
 
     &:nth-child(1)::before {
-      content: 'g';
-    }
-
-    &:nth-child(2)::before {
-
-    }
-
-    &:nth-child(3)::before {
-
-    }
-
-    &:nth-child(4)::before {
-
+      content: "g";
     }
   }
 }

--- a/javascript/src/components/dropzone/styles.scss
+++ b/javascript/src/components/dropzone/styles.scss
@@ -1,25 +1,25 @@
 .dropzone-component {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    margin: 70px 16px 0;
-    
-    &::after {
-        position: absolute;
-        top: -70px;
-        right: -16px;
-        bottom: 0;
-        left: -16px;
-        background: rgba(236, 239, 241, .9) url('#{$frameworkPath}/admin/images/drag_drop_opt.svg') center center no-repeat;
-        background-size: 312px 325px;
-        z-index: 100;
-    }
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  margin: 70px 16px 0;
 
-    &.dragging {
-        &::after {
-            content: '';
-        }
+  &::after {
+    position: absolute;
+    top: -70px;
+    right: -16px;
+    bottom: 0;
+    left: -16px;
+    background: rgba(236, 239, 241, .9) url('#{$frameworkPath}/admin/images/drag_drop_opt.svg') center center no-repeat;
+    background-size: 312px 325px;
+    z-index: 100;
+  }
+
+  &.dragging {
+    &::after {
+      content: '';
     }
+  }
 }

--- a/javascript/src/components/dropzone/styles.scss
+++ b/javascript/src/components/dropzone/styles.scss
@@ -1,3 +1,5 @@
+$dropzone-background: rgba(236, 239, 241, .9);
+
 .dropzone-component {
   position: absolute;
   top: 0;
@@ -12,14 +14,14 @@
     right: -16px;
     bottom: 0;
     left: -16px;
-    background: rgba(236, 239, 241, .9) url('#{$frameworkPath}/admin/images/drag_drop_opt.svg') center center no-repeat;
+    background: $dropzone-background url("#{$framework-path}/admin/images/drag_drop_opt.svg") center center no-repeat;
     background-size: 312px 325px;
     z-index: 100;
   }
 
   &.dragging {
     &::after {
-      content: '';
+      content: "";
     }
   }
 }

--- a/javascript/src/components/file/styles.scss
+++ b/javascript/src/components/file/styles.scss
@@ -1,244 +1,244 @@
 .asset-gallery {
 
-	.cms & p {
-		line-height: $line-height;
-	}
+  .cms & p {
+    line-height: $line-height;
+  }
 
-	.item--overlay {
-		background: rgba(darken($body-color, 10%), .5);
-		position: absolute;
-		top: 0;
-		right: 0;
-		left: 0;
-		opacity: 0;
-		display: none;
-		transition-property: opacity, background;
-		transition-duration: $transition-speed-mid;
-		color: #fff;
-		border-radius: $border-radius-sm $border-radius-sm 0 0;
-		height: $gallery-thumb-height;
-		width: 100%;
-		font-size: 14px;
-		padding-top: 56px;
-		text-align: center;
+  .item--overlay {
+    background: rgba(darken($body-color, 10%), .5);
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 0;
+    opacity: 0;
+    display: none;
+    transition-property: opacity, background;
+    transition-duration: $transition-speed-mid;
+    color: #fff;
+    border-radius: $border-radius-sm $border-radius-sm 0 0;
+    height: $gallery-thumb-height;
+    width: 100%;
+    font-size: 14px;
+    padding-top: 56px;
+    text-align: center;
 
-		&::before {
-			margin-right: 5px;
-		}
-	}
+    &::before {
+      margin-right: 5px;
+    }
+  }
 
-	.item {
-		position: relative;
-		float: left;
-		margin: 0 20px 20px 0;
-		background-color: #fff;
-		border: 1px solid;
-		border-color: $border-light $border-base $border-dark;
-		width: $gallery-item-width; 
-		border-radius: $border-radius-sm;
-		transition: box-shadow $transition-speed-fast;
-		height: $gallery-item-height;
-		
-		&:hover {
-			box-shadow: 0 1px 4px #ddd;
-			cursor: pointer;
-		}
+  .item {
+    position: relative;
+    float: left;
+    margin: 0 20px 20px 0;
+    background-color: #fff;
+    border: 1px solid;
+    border-color: $border-light $border-base $border-dark;
+    width: $gallery-item-width;
+    border-radius: $border-radius-sm;
+    transition: box-shadow $transition-speed-fast;
+    height: $gallery-item-height;
 
-		.item__thumbnail {
-			height: 132px;
-			width: $gallery-thumb-width;
-			margin: 0 auto;
-			background-repeat: no-repeat;
-			background-position: center center;
-			background-size: cover;
-			border-radius: $border-radius-sm $border-radius-sm 0 0;
+    &:hover {
+      box-shadow: 0 1px 4px #ddd;
+      cursor: pointer;
+    }
 
-			&--small {
-				background-size: auto;
-			}
-		}
+    .item__thumbnail {
+      height: 132px;
+      width: $gallery-thumb-width;
+      margin: 0 auto;
+      background-repeat: no-repeat;
+      background-position: center center;
+      background-size: cover;
+      border-radius: $border-radius-sm $border-radius-sm 0 0;
 
-		&:not(.item--error):not(.item--folder):hover .item--overlay {
-			opacity: 1;
-			display: block;
-		}
+      &--small {
+        background-size: auto;
+      }
+    }
 
-		&--focussed .item--overlay {
-			opacity: 1;
-			display: block;
-		}
-		
-		&--folder {
-			height: $gallery-folder-height;
+    &:not(.item--error):not(.item--folder):hover .item--overlay {
+      opacity: 1;
+      display: block;
+    }
 
-			.item__thumbnail {
-				background: url(img/folder.png) 12px 14px no-repeat;
-				background-size: 27px 24px;
-				height: $gallery-folder-height - 2;
-				width: 45px;
-				float: left;
-			}
+    &--focussed .item--overlay {
+      opacity: 1;
+      display: block;
+    }
 
-			.item__title {
-				padding: 17px 28px 17px 0;
-				width: 131px;
-				height: $gallery-folder-title-height;
-			} 
+    &--folder {
+      height: $gallery-folder-height;
 
-			.item__actions__action {
-				height: $gallery-folder-title-height;
-				padding-top: 9px;
-			}
-		}
+      .item__thumbnail {
+        background: url(img/folder.png) 12px 14px no-repeat;
+        background-size: 27px 24px;
+        height: $gallery-folder-height - 2;
+        width: 45px;
+        float: left;
+      }
 
-		&--archive {
-			.item__thumbnail {
-				background: #fff url(img/icon_zip.png) center center no-repeat;
-			}
-		}
+      .item__title {
+        padding: 17px 28px 17px 0;
+        width: 131px;
+        height: $gallery-folder-title-height;
+      }
 
-		&--audio {
-			.item__thumbnail {
-				background: #fff url(img/icon_audio.png) center center no-repeat;
-			}
-		}
+      .item__actions__action {
+        height: $gallery-folder-title-height;
+        padding-top: 9px;
+      }
+    }
 
-		&--video {
-			.item__thumbnail {
-				background: #fff url(img/icon_video.png) center center no-repeat;
-			}
-		}
+    &--archive {
+      .item__thumbnail {
+        background: #fff url(img/icon_zip.png) center center no-repeat;
+      }
+    }
 
-		&--document {
-			.item__thumbnail {
-				background: #fff url(img/icon_doc.png) center center no-repeat;
-			}
-		}
+    &--audio {
+      .item__thumbnail {
+        background: #fff url(img/icon_audio.png) center center no-repeat;
+      }
+    }
 
-		&--false {
-			.item__thumbnail {
-				background: #fff url(img/icon_file.png) center center no-repeat;
-			}
-		}
+    &--video {
+      .item__thumbnail {
+        background: #fff url(img/icon_video.png) center center no-repeat;
+      }
+    }
 
-		&--selected {
-			border-color: $state-active;
+    &--document {
+      .item__thumbnail {
+        background: #fff url(img/icon_doc.png) center center no-repeat;
+      }
+    }
 
-			.item__actions__action--select {
-				border-color: $state-active;
-				color: #fff;
-				opacity: 1;
+    &--false {
+      .item__thumbnail {
+        background: #fff url(img/icon_file.png) center center no-repeat;
+      }
+    }
 
-				&::before {
-					border-color: $state-active;
-					background-color: $state-active;
-				}
-			}
-		}
-		
-		&--error {
-			.item__thumbnail {
-				position: relative;
+    &--selected {
+      border-color: $state-active;
 
-				&::after {
-					content: '';
-					position: absolute;
-					top: 0;
-					left: 0;
-					right: 0;
-					bottom: 0;
-					background: $error;
-					opacity: .8;
-				}
-			}
-		}
-	}
+      .item__actions__action--select {
+        border-color: $state-active;
+        color: #fff;
+        opacity: 1;
 
-	.item__actions__action {
-		position: absolute;
-		right: 0;
-		top: 0;
-		height: $gallery-title-height;
-		padding: 8px 10px 6px;
-		margin-bottom: 0;
-		content: " ";
-		background-color: transparent;
-		border: 0;
-		background: none;
+        &::before {
+          border-color: $state-active;
+          background-color: $state-active;
+        }
+      }
+    }
 
-		&::before {
-			background-color: #fff;
-			font-size: 14px;
-			padding: 1px;
-		}
-		
-		&--select {
-			color: transparent;
+    &--error {
+      .item__thumbnail {
+        position: relative;
 
-			&:hover {
-				&::before {
-					border: 1px solid $state-active;
-				}
-			}
+        &::after {
+          content: '';
+          position: absolute;
+          top: 0;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          background: $error;
+          opacity: .8;
+        }
+      }
+    }
+  }
 
-			&::before {
-				border: 1px solid #ddd;
-				border-radius: $border-radius-sm;
-			}
-		}
-		
-		&--cancel {
-			color: lighten($color-text, 15%);
+  .item__actions__action {
+    position: absolute;
+    right: 0;
+    top: 0;
+    height: $gallery-title-height;
+    padding: 8px 10px 6px;
+    margin-bottom: 0;
+    content: " ";
+    background-color: transparent;
+    border: 0;
+    background: none;
 
-			&:hover {
-				color: $color-text;
-			}
-			
-			&::before {
-				font-size: 18px;
-				vertical-align: bottom;
-			}
-		}
-	}
-	
-	.item__upload-progress {
-		height: 18px;
-		width: 75%;
-		position: absolute;
-		top: calc(50% - 40px);
-		left: 50%;
-		transform: translateX(-50%) translateY(50%);
-		background: #ddd;
-		border-radius: 10px;
-		overflow: hidden;
-		
-		&__bar {
-			height: 100%;
-			background: $state-active;
-			background: #29abe2;
-			width: 0%;
-		}
-	}
+    &::before {
+      background-color: #fff;
+      font-size: 14px;
+      padding: 1px;
+    }
 
-	.item__title {
-		padding: 11px 28px 11px 12px;
-		height: $gallery-title-height;
-		width: $gallery-thumb-width;
-		margin: 0;
-		overflow: hidden;
-		box-sizing: border-box;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-		position: relative;
-	}
-	
-	.item__error-message {
-		position: absolute;
-		top: calc(50% - 40px);
-		left: 50%;
-		transform: translateX(-50%) translateY(50%);
-		width: 75%;
-		color: white;
-		text-align: center;
-	}
+    &--select {
+      color: transparent;
+
+      &:hover {
+        &::before {
+          border: 1px solid $state-active;
+        }
+      }
+
+      &::before {
+        border: 1px solid #ddd;
+        border-radius: $border-radius-sm;
+      }
+    }
+
+    &--cancel {
+      color: lighten($color-text, 15%);
+
+      &:hover {
+        color: $color-text;
+      }
+
+      &::before {
+        font-size: 18px;
+        vertical-align: bottom;
+      }
+    }
+  }
+
+  .item__upload-progress {
+    height: 18px;
+    width: 75%;
+    position: absolute;
+    top: calc(50% - 40px);
+    left: 50%;
+    transform: translateX(-50%) translateY(50%);
+    background: #ddd;
+    border-radius: 10px;
+    overflow: hidden;
+
+    &__bar {
+      height: 100%;
+      background: $state-active;
+      background: #29abe2;
+      width: 0%;
+    }
+  }
+
+  .item__title {
+    padding: 11px 28px 11px 12px;
+    height: $gallery-title-height;
+    width: $gallery-thumb-width;
+    margin: 0;
+    overflow: hidden;
+    box-sizing: border-box;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    position: relative;
+  }
+
+  .item__error-message {
+    position: absolute;
+    top: calc(50% - 40px);
+    left: 50%;
+    transform: translateX(-50%) translateY(50%);
+    width: 75%;
+    color: white;
+    text-align: center;
+  }
 }

--- a/javascript/src/components/file/styles.scss
+++ b/javascript/src/components/file/styles.scss
@@ -5,7 +5,7 @@
   }
 
   .item--overlay {
-    background: rgba(darken($body-color, 10%), .5);
+    background: $gallery-item-overlay-bg;
     position: absolute;
     top: 0;
     right: 0;
@@ -14,7 +14,7 @@
     display: none;
     transition-property: opacity, background;
     transition-duration: $transition-speed-mid;
-    color: #fff;
+    color: $gallery-item-overlay-text;
     border-radius: $border-radius-sm $border-radius-sm 0 0;
     height: $gallery-thumb-height;
     width: 100%;
@@ -31,7 +31,7 @@
     position: relative;
     float: left;
     margin: 0 20px 20px 0;
-    background-color: #fff;
+    background-color: $gallery-item-bg;
     border: 1px solid;
     border-color: $border-light $border-base $border-dark;
     width: $gallery-item-width;
@@ -40,7 +40,7 @@
     height: $gallery-item-height;
 
     &:hover {
-      box-shadow: 0 1px 4px #ddd;
+      box-shadow: 0 1px 4px $shadow-black-variant;
       cursor: pointer;
     }
 
@@ -72,7 +72,7 @@
       height: $gallery-folder-height;
 
       .item__thumbnail {
-        background: url(img/folder.png) 12px 14px no-repeat;
+        background: url("img/folder.png") 12px 14px no-repeat;
         background-size: 27px 24px;
         height: $gallery-folder-height - 2;
         width: 45px;
@@ -93,31 +93,31 @@
 
     &--archive {
       .item__thumbnail {
-        background: #fff url(img/icon_zip.png) center center no-repeat;
+        background: #fff url("img/icon_zip.png") center center no-repeat;
       }
     }
 
     &--audio {
       .item__thumbnail {
-        background: #fff url(img/icon_audio.png) center center no-repeat;
+        background: #fff url("img/icon_audio.png") center center no-repeat;
       }
     }
 
     &--video {
       .item__thumbnail {
-        background: #fff url(img/icon_video.png) center center no-repeat;
+        background: #fff url("img/icon_video.png") center center no-repeat;
       }
     }
 
     &--document {
       .item__thumbnail {
-        background: #fff url(img/icon_doc.png) center center no-repeat;
+        background: #fff url("img/icon_doc.png") center center no-repeat;
       }
     }
 
     &--false {
       .item__thumbnail {
-        background: #fff url(img/icon_file.png) center center no-repeat;
+        background: #fff url("img/icon_file.png") center center no-repeat;
       }
     }
 
@@ -126,7 +126,7 @@
 
       .item__actions__action--select {
         border-color: $state-active;
-        color: #fff;
+        color: $state-active-text;
         opacity: 1;
 
         &::before {
@@ -141,7 +141,7 @@
         position: relative;
 
         &::after {
-          content: '';
+          content: "";
           position: absolute;
           top: 0;
           left: 0;

--- a/javascript/src/sections/editor/styles.scss
+++ b/javascript/src/sections/editor/styles.scss
@@ -1,3 +1,3 @@
 .editor-component {
-    clear: both;
+  clear: both;
 }

--- a/javascript/src/sections/gallery/styles.scss
+++ b/javascript/src/sections/gallery/styles.scss
@@ -25,7 +25,7 @@
       margin-top: -1px;
 
       &:focus {
-        box-shadow: 0 0 3px 0 rgba(0,0,0,.2);
+        box-shadow: 0 0 3px 0 $shadow-black;
       }
 
       > span {
@@ -33,14 +33,14 @@
         color: inherit;
 
         &::before {
-          content: 'Sort by '
+          content: "Sort by ";
         }
       }
     }
 
     .chzn-drop {
       border-radius: 3px;
-      box-shadow: 0 0 3px rgba(0,0,0,.2);
+      box-shadow: 0 0 3px $shadow-black;
       border: 0;
     }
 
@@ -75,9 +75,9 @@
     width: 200px;
     font-size: 16px;
     height: 44px;
-    background-color: #338DC1;
+    background-color: #338dc1;
     border: 0;
-    border-radius: 4px
+    border-radius: 4px;
   }
 
   .gallery__upload,

--- a/javascript/src/sections/gallery/styles.scss
+++ b/javascript/src/sections/gallery/styles.scss
@@ -1,96 +1,96 @@
 .asset-gallery {
 
-    .gallery__no-item-notice {
-        width: 100%;
-        text-align: center;
+  .gallery__no-item-notice {
+    width: 100%;
+    text-align: center;
+  }
+
+  .gallery__back {
+    &.ss-ui-button::before {
+      font-size: 23px;
     }
+  }
 
-    .gallery__back {
-        &.ss-ui-button::before {
-            font-size: 23px;
-        }
-    }
+  .gallery__sort {
+    position: absolute;
+    top: 14px;
+    right: 16px;
 
-    .gallery__sort {
-        position: absolute;
-        top: 14px;
-        right: 16px;
+    .chzn-single {
+      border: 0;
+      filter: none; //IE9
+      background: none;
+      box-shadow: none;
+      color: inherit;
+      margin-top: -1px;
 
-        .chzn-single {
-            border: 0;
-            filter: none; //IE9
-            background: none;
-            box-shadow: none;
-            color: inherit;
-            margin-top: -1px;
+      &:focus {
+        box-shadow: 0 0 3px 0 rgba(0,0,0,.2);
+      }
 
-            &:focus {
-                box-shadow: 0 0 3px 0 rgba(0,0,0,.2);
-            }
+      > span {
+        text-align: right;
+        color: inherit;
 
-            > span {
-                text-align: right;
-                color: inherit;
-
-                &::before {
-                    content: 'Sort by '
-                }
-            }
-        }
-
-        .chzn-drop {
-            border-radius: 3px;
-            box-shadow: 0 0 3px rgba(0,0,0,.2);
-            border: 0;
-        }
-
-        .chzn-results {
-            .active-result {
-                text-transform: capitalize;
-            }
-        }
-    }
-
-    .gallery__folders {
-        display: inline-block;
-        width: 100%;
-    }
-    
-    .gallery__files {
-        display: inline-block;
-        width: 100%;
-    }
-
-    .gallery__load {
-        width: 100%;
-        display: inline-block;
-    }
-
-    .gallery__load__more {
-        display: block;
-        color: white;
-        cursor: pointer;
-        margin: 8px auto 24px;
-        padding: 4px;
-        width: 200px;
-        font-size: 16px;
-        height: 44px;
-        background-color: #338DC1;
-        border: 0;
-        border-radius: 4px
-    }
-
-    .gallery__upload,
-    .gallery__add-folder {
         &::before {
-            font-size: 24px !important;
+          content: 'Sort by '
         }
+      }
     }
 
-    .gallery__add-folder,
-    .gallery__upload,
-    .gallery__back {
-        margin: 12px 10px 12px 0;
-        border-radius: 4px;
+    .chzn-drop {
+      border-radius: 3px;
+      box-shadow: 0 0 3px rgba(0,0,0,.2);
+      border: 0;
     }
+
+    .chzn-results {
+      .active-result {
+        text-transform: capitalize;
+      }
+    }
+  }
+
+  .gallery__folders {
+    display: inline-block;
+    width: 100%;
+  }
+
+  .gallery__files {
+    display: inline-block;
+    width: 100%;
+  }
+
+  .gallery__load {
+    width: 100%;
+    display: inline-block;
+  }
+
+  .gallery__load__more {
+    display: block;
+    color: white;
+    cursor: pointer;
+    margin: 8px auto 24px;
+    padding: 4px;
+    width: 200px;
+    font-size: 16px;
+    height: 44px;
+    background-color: #338DC1;
+    border: 0;
+    border-radius: 4px
+  }
+
+  .gallery__upload,
+  .gallery__add-folder {
+    &::before {
+      font-size: 24px !important;
+    }
+  }
+
+  .gallery__add-folder,
+  .gallery__upload,
+  .gallery__back {
+    margin: 12px 10px 12px 0;
+    border-radius: 4px;
+  }
 }

--- a/javascript/src/styles/AssetAdmin.scss
+++ b/javascript/src/styles/AssetAdmin.scss
@@ -16,18 +16,16 @@
 
     .cms-edit-form.AssetAdmin {
       width: 100%;
-      overflow-y:auto; //adds scrolling only to the datagrid
+      overflow-y: auto; //adds scrolling only to the datagrid
     }
 
-    /**
-     * DEPRECATED:
-     * .cms-content-tools will be removed in 4.0
-     * Use .cms-content-filters instead.
-     */
+    // DEPRECATED:
+    // .cms-content-tools will be removed in 4.0
+    // Use .cms-content-filters instead.
     .cms-content-tools .cms-panel-content {
-      overflow:hidden; //removes scollbar from search field in filter
+      overflow: hidden; //removes scollbar from search field in filter
       .cms-search-form {
-        height:100%; //increases height of search form to accomodate dropdown
+        height: 100%; //increases height of search form to accomodate dropdown
       }
     }
   }
@@ -52,25 +50,25 @@
     }
 
     .cms-page-add-button {
-      border-color:#c0c0c2;
+      border-color: #c0c0c2;
       span.btn-icon-add {
-        height:17px;
+        height: 17px;
       }
       span.ui-button-text {
-        color:#393939;
-        text-shadow: white 0 1px 1px;
+        color: #393939;
+        text-shadow: #ffffff 0 1px 1px;
       }
     }
   }
 
   #Root_TreeView {
     .cms-tree ul .class-Folder a span.text span.jstree-foldericon {
-      background: url(img/blue-folder-horizontal.png) no-repeat;
-      width:16px;
-      height:16px;
-      float:left;
-      display:block;
-      margin-right:4px;
+      background: url("img/blue-folder-horizontal.png") no-repeat;
+      width: 16px;
+      height: 16px;
+      float: left;
+      display: block;
+      margin-right: 4px;
     }
   }
 
@@ -81,37 +79,37 @@
   table.ss-gridfield-table {
     td {
       &.bottom-all {
-        padding:0.7em;
+        padding: 0.7em;
       }
     }
     tr[data-class=Folder] {
       td.col-StripThumbnail {
-        background: transparent url(img/treeicons/blue-folder-horizontal.png) no-repeat center;
+        background: transparent url("img/treeicons/blue-folder-horizontal.png") no-repeat center;
       }
     }
     tr[data-class=File] {
       td.col-StripThumbnail {
-        background: transparent url(img/treeicons/blue-document.png) no-repeat center;
+        background: transparent url("img/treeicons/blue-document.png") no-repeat center;
       }
     }
   }
 
 
-  /* Gallery actions bar */
+  // Gallery actions bar
   .cms-actions-row {
     margin-bottom: 0;
   }
 
-  /* TEMP Overides which should eventually not be needed */
+  // TEMP Overides which should eventually not be needed
 
   // Reset some annoying CMS styles.
   .asset-gallery {
     > .left {
-        display: none !important;
+      display: none !important;
     }
 
     > .middleColumn {
-        margin-left: 0;
+       margin-left: 0;
     }
   }
 

--- a/javascript/src/styles/AssetAdmin.scss
+++ b/javascript/src/styles/AssetAdmin.scss
@@ -1,139 +1,139 @@
 .cms .AssetAdmin {
-	.tabset {
-		margin: 0;
-		box-shadow: 0;
-		padding: 0;
-		border: 0;
-	}
+  .tabset {
+    margin: 0;
+    box-shadow: 0;
+    padding: 0;
+    border: 0;
+  }
 
-	.cms-content-view {
-		position: relative;
-		min-height: 100%;
-	}
+  .cms-content-view {
+    position: relative;
+    min-height: 100%;
+  }
 
-	.cms-content-fields {
-		overflow-x: hidden; //hides 'allowed extensions' sidebar
+  .cms-content-fields {
+    overflow-x: hidden; //hides 'allowed extensions' sidebar
 
-		.cms-edit-form.AssetAdmin {
-			width: 100%;
-			overflow-y:auto; //adds scrolling only to the datagrid
-		}
+    .cms-edit-form.AssetAdmin {
+      width: 100%;
+      overflow-y:auto; //adds scrolling only to the datagrid
+    }
 
-		/**
-		 * DEPRECATED:
-		 * .cms-content-tools will be removed in 4.0
-		 * Use .cms-content-filters instead.
-		 */
-		.cms-content-tools .cms-panel-content {
-			overflow:hidden; //removes scollbar from search field in filter
-			.cms-search-form {
-				height:100%; //increases height of search form to accomodate dropdown
-			}
-		}
-	}
+    /**
+     * DEPRECATED:
+     * .cms-content-tools will be removed in 4.0
+     * Use .cms-content-filters instead.
+     */
+    .cms-content-tools .cms-panel-content {
+      overflow:hidden; //removes scollbar from search field in filter
+      .cms-search-form {
+        height:100%; //increases height of search form to accomodate dropdown
+      }
+    }
+  }
 
-	.cms-content-toolbar {
-		float: left;
+  .cms-content-toolbar {
+    float: left;
 
-		.cms-actions-row {
-			.ss-ui-button {
-				z-index: 1;
-				margin: 0;
-				padding: 5px 6px;
+    .cms-actions-row {
+      .ss-ui-button {
+        z-index: 1;
+        margin: 0;
+        padding: 5px 6px;
 
-				&::before {
-					font-size: 23px;
-				}
-			}
+        &::before {
+          font-size: 23px;
+        }
+      }
 
-			.grid-levelup {
-				margin: 0;
-			}
-		}
+      .grid-levelup {
+        margin: 0;
+      }
+    }
 
-		.cms-page-add-button {
-			border-color:#c0c0c2;
-			span.btn-icon-add {
-				height:17px;
-			}
-			span.ui-button-text {
-				color:#393939;
-				text-shadow: white 0 1px 1px;
-			}
-		}
-	}
+    .cms-page-add-button {
+      border-color:#c0c0c2;
+      span.btn-icon-add {
+        height:17px;
+      }
+      span.ui-button-text {
+        color:#393939;
+        text-shadow: white 0 1px 1px;
+      }
+    }
+  }
 
-	#Root_TreeView {
-		.cms-tree ul .class-Folder a span.text span.jstree-foldericon {
-			background: url(img/blue-folder-horizontal.png) no-repeat;
-			width:16px;
-			height:16px;
-			float:left;
-			display:block;
-			margin-right:4px;
-		}
-	}
+  #Root_TreeView {
+    .cms-tree ul .class-Folder a span.text span.jstree-foldericon {
+      background: url(img/blue-folder-horizontal.png) no-repeat;
+      width:16px;
+      height:16px;
+      float:left;
+      display:block;
+      margin-right:4px;
+    }
+  }
 
-	.ss-gridfield {
-		margin-top: 0;
-	}
+  .ss-gridfield {
+    margin-top: 0;
+  }
 
-	table.ss-gridfield-table {
-		td {
-			&.bottom-all {
-				padding:0.7em;
-			}
-		}
-		tr[data-class=Folder] {
-			td.col-StripThumbnail {
-				background: transparent url(img/treeicons/blue-folder-horizontal.png) no-repeat center;
-			}
-		}
-		tr[data-class=File] {
-			td.col-StripThumbnail {
-				background: transparent url(img/treeicons/blue-document.png) no-repeat center;
-			}
-		}
-	}
+  table.ss-gridfield-table {
+    td {
+      &.bottom-all {
+        padding:0.7em;
+      }
+    }
+    tr[data-class=Folder] {
+      td.col-StripThumbnail {
+        background: transparent url(img/treeicons/blue-folder-horizontal.png) no-repeat center;
+      }
+    }
+    tr[data-class=File] {
+      td.col-StripThumbnail {
+        background: transparent url(img/treeicons/blue-document.png) no-repeat center;
+      }
+    }
+  }
 
 
-	/* Gallery actions bar */
-	.cms-actions-row {
-		margin-bottom: 0;
-	}
+  /* Gallery actions bar */
+  .cms-actions-row {
+    margin-bottom: 0;
+  }
 
-	/* TEMP Overides which should eventually not be needed */
+  /* TEMP Overides which should eventually not be needed */
 
-	// Reset some annoying CMS styles.
-	.asset-gallery {
-	    > .left {
-	        display: none !important;
-	    }
+  // Reset some annoying CMS styles.
+  .asset-gallery {
+    > .left {
+        display: none !important;
+    }
 
-	    > .middleColumn {
-	        margin-left: 0;
-	    }
-	}
+    > .middleColumn {
+        margin-left: 0;
+    }
+  }
 
-	.icon-button-group {
-		// TODO Re-enable once list view is in place
-		display: none;
-		margin-top: 0;
-	}
+  .icon-button-group {
+    // TODO Re-enable once list view is in place
+    display: none;
+    margin-top: 0;
+  }
 
-	.cms-content-toolbar {
-		margin: 0;
-	}
+  .cms-content-toolbar {
+    margin: 0;
+  }
 
-	.cms-actions-row {
-		margin-top: 12px;
+  .cms-actions-row {
+    margin-top: 12px;
 
-		.ss-ui-button {
-			margin-bottom: 10px;
+    .ss-ui-button {
+      margin-bottom: 10px;
 
-			&[class*="font-icon-folder-add"]::before {
-				font-size: 24px;
-			}
-		}
-	}
+      &[class*="font-icon-folder-add"]::before {
+        font-size: 24px;
+      }
+    }
+  }
 }

--- a/javascript/src/styles/main.scss
+++ b/javascript/src/styles/main.scss
@@ -1,7 +1,7 @@
-@import 'variables';
-@import '../sections/gallery/styles';
-@import '../sections/editor/styles';
-@import '../components/file/styles';
-@import '../components/bulk-actions/styles';
-@import '../components/dropzone/styles';
-@import 'AssetAdmin'
+@import "variables";
+@import "../sections/gallery/styles";
+@import "../sections/editor/styles";
+@import "../components/file/styles";
+@import "../components/bulk-actions/styles";
+@import "../components/dropzone/styles";
+@import "AssetAdmin";

--- a/javascript/src/styles/variables.scss
+++ b/javascript/src/styles/variables.scss
@@ -4,37 +4,41 @@
 //
 
 $state-active:              #29abe2 !default;
-$error:                     #D30000 !default;
+$error:                     #d30000 !default;
 $color-text:                #66727d !default;
 
+$state-active-text:         #ffffff;
 
 // Body
 //
 // Settings for the `<body>` element.
 
-$body-color:                 #4f5861 !default;          /* eg. Text, labels, iconography */ 
-$body-color-light:           lighten($body-color, 10%); /* eg. Field descriptions */
-$body-color-lighter:         lighten($body-color, 20%); /* eg. placeholder text */
-$body-color-dark:            darken($body-color, 10%);  /* eg. iconography hovered */
+$body-color:                 #4f5861 !default;          // eg. Text, labels, iconography
+$body-color-light:           lighten($body-color, 10%); // eg. Field descriptions
+$body-color-lighter:         lighten($body-color, 20%); // eg. placeholder text
+$body-color-dark:            darken($body-color, 10%);  // eg. iconography hovered
 
 $body-bg:                    #f6f7f8 !default;
-$body-bg-dark:               darken($body-bg, 2%);      /* eg. North bar */
+$body-bg-dark:               darken($body-bg, 2%);      // eg. North bar
 $menu-bg:                    #e9f0f4 !default;
 $menu-link-active:           darken($menu-bg, 5%);
 $menu-icon-color:            darken($menu-bg, 32%);
 
 // borders colors
-$border-light:               darken($body-bg,6%);
-$border-base:                darken($body-bg,10%);
-$border-dark:                darken($body-bg,14%);
-$border-darker:              darken($body-bg,20%);
+$border-light:               darken($body-bg, 6%);
+$border-base:                darken($body-bg, 10%);
+$border-dark:                darken($body-bg, 14%);
+$border-darker:              darken($body-bg, 20%);
 
+// shadow
+$shadow-black:               rgba(0, 0, 0, .2);
+$shadow-black-variant:       #ddd; // TODO: perhaps $shadow-black should be used for consistency?
 
 // Links
 //
 // Style anchor elements.
 
-$link-color:                 #0073C1 !default;
+$link-color:                 #0073c1 !default;
 
 
 // Typography
@@ -47,9 +51,9 @@ $line-height:                1.5 !default;
 // Components
 //
 
-$border-radius:              .25rem !default;   /* 4px */
-$border-radius-lg:           .375rem !default;  /* 6px */
-$border-radius-sm:           .125rem !default;  /* 2px */
+$border-radius:              .25rem !default;   // 4px
+$border-radius-lg:           .375rem !default;  // 6px
+$border-radius-sm:           .125rem !default;  // 2px
 $card-border-color:          $border-base;
 
 
@@ -59,12 +63,16 @@ $card-border-color:          $border-base;
 $gallery-thumb-width:         176px;
 $gallery-thumb-height:        132px;
 
-$gallery-item-width:          $gallery-thumb-width + 2; /* include borders */
+$gallery-item-width:          $gallery-thumb-width + 2; // include borders
 $gallery-item-height:         174px;
 $gallery-title-height:        40px;
 
 $gallery-folder-height:	      54px;
 $gallery-folder-title-height: $gallery-folder-height - 2;
+
+$gallery-item-bg:             #ffffff;
+$gallery-item-overlay-bg:     rgba(darken($body-color, 10%), .5);
+$gallery-item-overlay-text:   #ffffff;
 
 
 // Transition speeds
@@ -77,5 +85,7 @@ $transition-speed-fast:       .3s;
 // Paths
 //
 
-$rootPath:                    '../..';
-$frameworkPath:               '../../../framework';
+$root-path:                    "../..";
+$framework-path:               "../../../framework";
+
+

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "NODE_PATH=\"./javascript/src\" jest",
     "coverage": "jest --coverage",
     "lock": "npm-shrinkwrap --dev",
-    "lint": "eslint javascript/src"
+    "lint": "eslint javascript/src && sass-lint -c .sass-lint.yml --verbose"
   },
   "jest": {
     "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
@@ -61,6 +61,7 @@
     "redux-logger": "^2.4.0",
     "redux-mock-store": "0.0.6",
     "redux-thunk": "^1.0.3",
+    "sass-lint": "^1.5.1",
     "semver": "^5.0.3",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",


### PR DESCRIPTION
sass-lint has been chosen becausee it’s Node-based and supports SCSS.

The rule-set has been derived form the AirBNB standard by and automated
converter, but could probably be improved.

The ‘npm run lint’ command has been broadened to include a call to this.

Installation is with npm install --save-dev rather than npm install -g
to minimise the dev effort needed to set up an environment.