### PR TITLE
Rename original AssetAdmin to "Files (old)"

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -2,5 +2,4 @@
 Name: assetadmin
 ---
 AssetAdmin:
-  menu_title: 'Files2'
   url_segment: 'old-assets'

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -19,7 +19,7 @@ en:
     FROMYOURCOMPUTER: 'From your computer'
     Filetype: 'File type'
     ListView: 'List View'
-    MENUTITLE: Files
+    MENUTITLE: Files (old)
     NEWFOLDER: NewFolder
     SIZE: Size
     THUMBSDELETED: '{count} unused thumbnails have been deleted'
@@ -50,3 +50,5 @@ en:
     PreviewButton: Preview
   Permission:
     CMS_ACCESS_CATEGORY: 'CMS Access'
+  SilverStripe\AssetAdmin\Controller\AssetAdmin:
+    MENUTITLE: Files


### PR DESCRIPTION
Can't use menu_title via YAML config if a _t() key is defined.
Using the fully qualified class name here, the YAML parser
doesn't seem to mind the backslashes.

Will only apply in English for now, since other languages have their own translation keys. Since this is a temporary situation, there's not much point going through the hassle to change all of these IMHO

Merge with https://github.com/silverstripe/silverstripe-framework/pull/5366