### PR TITLE
npm install on framework to fix builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,9 @@ before_script:
 
 script:
     - "if [ \"$NPM_TEST\" = \"\" ]; then vendor/bin/phpunit asset-admin/tests/php; fi"
-    - "if [ \"$NPM_TEST\" = \"1\" ]; then (cd asset-admin && nvm install 4 && nvm use 4 && npm install --silent); fi"
+    - "if [ \"$NPM_TEST\" = \"1\" ]; then (nvm install 4); fi"
+    - "if [ \"$NPM_TEST\" = \"1\" ]; then (cd framework && nvm use 4 && npm install --silent); fi"
+    - "if [ \"$NPM_TEST\" = \"1\" ]; then (cd asset-admin && nvm use 4 && npm install --silent); fi"
     - "if [ \"$NPM_TEST\" = \"1\" ]; then (cd asset-admin && nvm use 4 && npm run test); fi"
 
 notifications:


### PR DESCRIPTION
- babel needs to transform ES6 test files
- it tries to find a babel config (in `.babelrc` or `package.json`) for each file its loading
- at some point during test exec, it its the first ES6 file in framework (`../framework/admin/client/src/lib/SilverStripeComponent.js`)
- goes up the directory, finds `framework/package.json`
- tries to load ES6 module dependencies in that file relative to that
- fails with `Couldn't find preset "react" relative to directory "/Users/ingo/builds/ss/framework"`
- because we haven’t run `npm install` on `framework` (since its a asset-admin build)

This is a short-term fix, we need to look into publishing
node_modules instead of hacking around with NODE_PATH
across SS modules.