### PR TITLE
Disable legacy preview behaviour

### DIFF
--- a/code/Controller/AssetAdmin.php
+++ b/code/Controller/AssetAdmin.php
@@ -237,6 +237,12 @@ class AssetAdmin extends LeftAndMain implements PermissionProvider
     public function getEditForm($id = null, $fields = null)
     {
         $form = parent::getEditForm($id, $fields);
+        
+        // Remove legacy previewable behaviour.
+        // Can't yet be cleanly removed from JS logic since its loaded via LeftAndMain.ss.
+        $form->removeExtraClass('cms-previewable');
+        $form->Fields()->removeByName('SilverStripeNavigator');
+        
         $folder = ($id && is_numeric($id)) ? DataObject::get_by_id('Folder', $id, false) : $this->currentPage();
         $title = ($folder && $folder->exists()) ? $folder->Title : _t('AssetAdmin.FILES', 'Files');
 


### PR DESCRIPTION
The preview panel markup is loaded via LeftAndMain.ss for all
controllers, regardless if they're using preview or not.
The markup has to be available in any subsequent PJAX calls
in order to allow for CMS sections to opt-in to previews.

This opt-in happens by adding a 'cms-previewable' class to the
edit form, which triggers the layout change. As part of the ReactJS
work, the File object implemented the CMSPreviewable interface,
which triggered this class - and subsequently the layout
switching behaviour.

See https://github.com/silverstripe/silverstripe-framework/commit/4be5e7c961f7041dd5babb10d6d5550766f8c7be