### PR TITLE
Increase specificity of hidden tabs in AssetAdmin

### DIFF
--- a/client/dist/styles/bundle.css
+++ b/client/dist/styles/bundle.css
@@ -401,5 +401,5 @@
   display: none;
   margin-top: 0; }
 
-.cms-content-header-tabs {
+.AssetAdmin .cms-content-header-tabs {
   display: none; }

--- a/client/src/containers/AssetAdmin/AssetAdmin.scss
+++ b/client/src/containers/AssetAdmin/AssetAdmin.scss
@@ -45,9 +45,9 @@
     display: none;
     margin-top: 0;
   }
-}
 
-// Hide search for AssetAdmin for Alpha1 only
-.cms-content-header-tabs {
-  display: none;
+  // Hide search for AssetAdmin for Alpha1 only
+  .cms-content-header-tabs {
+    display: none;
+  }
 }


### PR DESCRIPTION
Increase specificity of hidden tabs in AssetAdmin as they override other areas. Without this fix CMS page tabs are hidden.