### PR TITLE
Remove horizontal scroll on old asset admin grid

### DIFF
--- a/client/dist/styles/bundle.css
+++ b/client/dist/styles/bundle.css
@@ -425,7 +425,7 @@
   text-overflow: ellipsis; }
 
 .editor__url-icon::before {
-  color: #a1a6a9; }
+  color: #a1aab2; }
 
 .editor__file-preview {
   text-align: center;
@@ -479,8 +479,7 @@
   overflow-x: hidden; }
 
 .AssetAdmin .cms-edit-form.AssetAdmin {
-  width: 100%;
-  overflow-y: auto; }
+  width: 100%; }
 
 .AssetAdmin .asset-gallery {
   margin: 0; }

--- a/client/src/containers/AssetAdmin/AssetAdmin.scss
+++ b/client/src/containers/AssetAdmin/AssetAdmin.scss
@@ -24,7 +24,6 @@
 
   .cms-edit-form.AssetAdmin {
     width: 100%;
-    overflow-y: auto; //adds scrolling only to the datagrid
   }
 
   // TEMP Overrides which should eventually not be needed


### PR DESCRIPTION
Remove overflow from old asset-admin so the grid-field (list view) can extend to edge of panel.

Requires "features/4.0/gridfield-styles" branches from Reports, CMS & Framework
silverstripe/silverstripe-cms#1541
https://github.com/silverstripe/silverstripe-framework/pull/5795
https://github.com/silverstripe-labs/silverstripe-reports/pull/36
