### PR TITLE
Code Coverage via CodeCov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,14 @@ matrix:
     - php: 5.5
     - php: 5.6
     - php: 7.0
-      env:
+      env: PHPUNIT_COVERAGE_TEST=1
     - php: 5.6
       env: NPM_TEST=1
 
 before_script:
+    - composer self-update || true
+    - phpenv rehash
+    - phpenv config-rm xdebug.ini
     - git clone -b "pulls/alias-and-installer-branch" git://github.com/chillu/silverstripe-travis-support.git ~/travis-support
     - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss
     - cd ~/builds/ss
@@ -26,6 +29,8 @@ script:
     - "if [ \"$NPM_TEST\" = \"1\" ]; then (cd asset-admin && nvm use 4 && npm install --silent); fi"
     - "if [ \"$NPM_TEST\" = \"1\" ]; then (cd asset-admin && nvm use 4 && npm run test); fi"
     - "if [ \"$NPM_TEST\" = \"1\" ]; then (cd asset-admin && nvm use 4 && npm run lint); fi"
+    - "if [ \"$PHPUNIT_COVERAGE_TEST\" = \"1\" ]; then phpdbg -qrr vendor/bin/phpunit asset-admin/tests --coverage-clover=coverage.xml; fi"
+    - "if [ \"$PHPUNIT_COVERAGE_TEST\" = \"1\" ]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml; fi"
 
 notifications:
   slack: silverstripeltd:Cls1xnypKBLFhv0YIRtNLzlQ

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,17 @@ env:
 matrix:
   include:
     - php: 5.5
+      env: DB=MYSQL PHPUNIT_TEST=1
+    - php: 5.5
+      env: DB=PGSQL PHPUNIT_TEST=1
+    - php: 5.5
+      env: DB=SQLITE PHPUNIT_TEST=1
     - php: 5.6
-    - php: 7.0
-      env: PHPUNIT_COVERAGE_TEST=1
+      env: DB=MYSQL PDO=1 PHPUNIT_TEST=1
     - php: 5.6
       env: NPM_TEST=1
+    - php: 7.0
+      env: DB=MYSQL PDO=1 PHPUNIT_COVERAGE_TEST=1
 
 before_script:
     - composer self-update || true
@@ -23,7 +29,7 @@ before_script:
     - cd ~/builds/ss
 
 script:
-    - "if [ \"$NPM_TEST\" = \"\" ]; then vendor/bin/phpunit asset-admin/tests/php; fi"
+    - "if [ \"$PHPUNIT_TEST\" = \"1\" ]; then vendor/bin/phpunit asset-admin/tests/php; fi"
     - "if [ \"$NPM_TEST\" = \"1\" ]; then (nvm install 4); fi"
     - "if [ \"$NPM_TEST\" = \"1\" ]; then (cd framework && nvm use 4 && npm install --silent); fi"
     - "if [ \"$NPM_TEST\" = \"1\" ]; then (cd asset-admin && nvm use 4 && npm install --silent); fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ matrix:
       env: NPM_TEST=1
     - php: 7.0
       env: DB=MYSQL PDO=1 PHPUNIT_COVERAGE_TEST=1
+  allow_failures:
+    - php: 5.5
+      env: DB=PGSQL PHPUNIT_TEST=1
 
 before_script:
     - composer self-update || true

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](http://img.shields.io/travis/silverstripe/silverstripe-asset-admin.svg?style=flat-square)](https://travis-ci.org/silverstripe/silverstripe-asset-admin)
 [![Code Quality](http://img.shields.io/scrutinizer/g/silverstripe/silverstripe-asset-admin.svg?style=flat-square)](https://scrutinizer-ci.com/g/silverstripe/silverstripe-asset-admin)
 [![Code Climate](https://codeclimate.com/github/silverstripe/silverstripe-asset-admin/badges/gpa.svg)](https://codeclimate.com/github/silverstripe/silverstripe-asset-admin)
+[![codecov](https://codecov.io/gh/silverstripe/silverstripe-asset-admin/branch/master/graph/badge.svg)](https://codecov.io/gh/silverstripe/silverstripe-asset-admin)
 [![Version](http://img.shields.io/packagist/v/silverstripe/asset-admin.svg?style=flat-square)](https://packagist.org/packages/silverstripe/asset-admin)
 [![License](http://img.shields.io/packagist/l/silverstripe/asset-admin.svg?style=flat-square)](LICENSE.md)
 ![helpfulrobot](https://helpfulrobot.io/silverstripe/asset-admin/badge)

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,14 +9,19 @@
     stopOnFailure="false"
     syntaxCheck="false"
     >
+
     <testsuites>
         <testsuite>
             <directory suffix="Test.php">tests</directory>
         </testsuite>
     </testsuites>
+
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">code</directory>
+            <directory suffix=".php">.</directory>
+            <exclude>
+                <directory suffix=".php">tests/</directory>
+            </exclude>
         </whitelist>
     </filter>
 </phpunit>


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-framework/pull/6089

The `whitelist` changes in `phpunit.xml` won't get picked up until we run `cms` builds without `travis-support` (out of scope for this PR)
