### PR TITLE
Adjust thumbnail size for gallery items

### DIFF
--- a/client/dist/js/bundle.js
+++ b/client/dist/js/bundle.js
@@ -575,7 +575,8 @@ var n=o(this,(t.__proto__||Object.getPrototypeOf(t)).call(this,e))
 return n.handleToggleSelect=n.handleToggleSelect.bind(n),n.handleDelete=n.handleDelete.bind(n),n.handleActivate=n.handleActivate.bind(n),n.handleKeyDown=n.handleKeyDown.bind(n),n.handleCancelUpload=n.handleCancelUpload.bind(n),
 n.preventFocus=n.preventFocus.bind(n),n}return l(t,e),a(t,[{key:"handleActivate",value:function n(e){e.stopPropagation(),this.props.handleActivate(e,this.props.item)}},{key:"handleToggleSelect",value:function i(e){
 e.stopPropagation(),e.preventDefault(),this.props.handleToggleSelect(e,this.props.item)}},{key:"handleDelete",value:function s(e){this.props.handleDelete(e,this.props.item)}},{key:"getThumbnailStyles",
-value:function d(){return this.isImage()&&(this.exists()||this.uploading())?{backgroundImage:"url("+this.props.item.url+")"}:{}}},{key:"hasError",value:function c(){var c=!1
+value:function d(){if(this.isImage()&&(this.exists()||this.uploading())){var e=this.props.item.thumbnail||this.props.item.url
+return{backgroundImage:"url("+e+")"}}return{}}},{key:"hasError",value:function c(){var c=!1
 return Array.isArray(this.props.messages)&&(c=this.props.messages.filter(function(e){return"error"===e.type}).length>0),c}},{key:"getErrorMessage",value:function h(){var e=null
 return this.hasError()?e=this.props.messages[0].value:this.exists()||this.uploading()||(e=u["default"]._t("AssetAdmin.FILE_MISSING","File cannot be found")),null!==e?p["default"].createElement("span",{
 className:"gallery-item__error-message"},e):null}},{key:"getThumbnailClassNames",value:function m(){var e=["gallery-item__thumbnail"]

--- a/client/src/components/GalleryItem/GalleryItem.js
+++ b/client/src/components/GalleryItem/GalleryItem.js
@@ -52,8 +52,9 @@ class GalleryItem extends SilverStripeComponent {
    */
   getThumbnailStyles() {
     if (this.isImage() && (this.exists() || this.uploading())) {
+      const thumbnail = this.props.item.thumbnail || this.props.item.url;
       return {
-        backgroundImage: `url(${this.props.item.url})`,
+        backgroundImage: `url(${thumbnail})`,
       };
     }
 

--- a/code/Controller/AssetAdmin.php
+++ b/code/Controller/AssetAdmin.php
@@ -7,11 +7,13 @@ use SilverStripe\Admin\CMSBatchActionHandler;
 use SilverStripe\Admin\LeftAndMain;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Folder;
+use SilverStripe\Assets\ImageManipulation;
 use SilverStripe\Assets\Storage\AssetNameGenerator;
 use SilverStripe\Assets\Upload;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Convert;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\CheckboxField;
@@ -92,6 +94,10 @@ class AssetAdmin extends LeftAndMain implements PermissionProvider
     );
 
     private static $required_permission_codes = 'CMS_ACCESS_AssetAdmin';
+    
+    private static $thumbnail_width = 400;
+    
+    private static $thumbnail_height = 300;
 
     /**
      * Set up the controller
@@ -709,6 +715,10 @@ class AssetAdmin extends LeftAndMain implements PermissionProvider
 
         /** @var File $file */
         if ($file->getIsImage()) {
+            $width = (int)Config::inst()->get(self::class, 'thumbnail_width');
+            $height = (int)Config::inst()->get(self::class, 'thumbnail_height');
+    
+            $object['thumbnail'] = $file->FitMax($width, $height)->getAbsoluteURL();
             $object['dimensions']['width'] = $file->Width;
             $object['dimensions']['height'] = $file->Height;
         }

--- a/code/Controller/AssetAdmin.php
+++ b/code/Controller/AssetAdmin.php
@@ -94,9 +94,9 @@ class AssetAdmin extends LeftAndMain implements PermissionProvider
     );
 
     private static $required_permission_codes = 'CMS_ACCESS_AssetAdmin';
-    
+
     private static $thumbnail_width = 400;
-    
+
     private static $thumbnail_height = 300;
 
     /**
@@ -717,8 +717,11 @@ class AssetAdmin extends LeftAndMain implements PermissionProvider
         if ($file->getIsImage()) {
             $width = (int)Config::inst()->get(self::class, 'thumbnail_width');
             $height = (int)Config::inst()->get(self::class, 'thumbnail_height');
-    
-            $object['thumbnail'] = $file->FitMax($width, $height)->getAbsoluteURL();
+
+            $thumbnail = $file->FitMax($width, $height);
+            if ($thumbnail && $thumbnail->exists()) {
+                $object['thumbnail'] = $thumbnail->getAbsoluteURL();
+            }
             $object['dimensions']['width'] = $file->Width;
             $object['dimensions']['height'] = $file->Height;
         }


### PR DESCRIPTION
This is to improve loading speed and user experience, so for images it no longer downloads the full image.

Fixes https://github.com/silverstripe/silverstripe-asset-admin/issues/237