### PR TITLE
Move link to files/images to the preview icon/image

### DIFF
--- a/client/dist/styles/bundle.css
+++ b/client/dist/styles/bundle.css
@@ -611,6 +611,11 @@
   text-decoration:none;
 }
 
+.editor__file-preview:hover .editor__thumbnail{
+  -webkit-transform:scale(1.04);
+          transform:scale(1.04);
+}
+
 .editor__file-preview-link:before{
   position:absolute;
   top:50%;
@@ -621,18 +626,21 @@
   height:50px;
   width:50px;
   border-radius:50%;
-  background-color:#000;
+  background-color:rgba(0,0,0,.6);
   color:#fff;
   font-size:24px;
   opacity:0;
   content:"s";
   font-family:silverstripe;
   line-height:27px;
+  z-index:1;
+  -webkit-transition:all .5s;
+  transition:all .5s;
 }
 
-.editor__file-preview-link:active:before,.editor__file-preview-link:hover:before{
+.editor__file-preview-link:active:before,.editor__file-preview-link:hover,.editor__file-preview-link:hover:before{
   text-decoration:none;
-  opacity:.6;
+  opacity:1;
 }
 
 .editor__thumbnail{
@@ -640,6 +648,10 @@
   max-height:336px;
   min-height:60px;
   margin:auto;
+  -webkit-transform:scale(1);
+          transform:scale(1);
+  -webkit-transition:all .5s;
+  transition:all .5s;
 }
 
 .cms .AssetAdmin .cms-content-view{

--- a/client/dist/styles/bundle.css
+++ b/client/dist/styles/bundle.css
@@ -654,6 +654,12 @@
   transition:all .5s;
 }
 
+.editor__file-preview-message--file-missing{
+  margin:2.4616rem 0 1.2308rem;
+  font-size:1.23rem;
+  color:#d40404;
+}
+
 .cms .AssetAdmin .cms-content-view{
   position:relative;
   min-height:100%;

--- a/client/dist/styles/bundle.css
+++ b/client/dist/styles/bundle.css
@@ -611,9 +611,8 @@
   text-decoration:none;
 }
 
-.editor__file-preview:before{
+.editor__file-preview-link:before{
   position:absolute;
-  display:none;
   top:50%;
   left:50%;
   margin-top:-25px;
@@ -625,14 +624,15 @@
   background-color:#000;
   color:#fff;
   font-size:24px;
-  opacity:.6;
+  opacity:0;
   content:"s";
   font-family:silverstripe;
   line-height:27px;
 }
 
-.editor__file-preview:active:before,.editor__file-preview:hover:before{
+.editor__file-preview-link:active:before,.editor__file-preview-link:hover:before{
   text-decoration:none;
+  opacity:.6;
 }
 
 .editor__thumbnail{

--- a/client/src/containers/Editor/Editor.scss
+++ b/client/src/containers/Editor/Editor.scss
@@ -60,9 +60,14 @@
   display: block;
   align-items: center;
   text-decoration: none;
+
+  &:hover .editor__thumbnail {
+    transform: scale(1.04);
+  }
 }
 
 .editor__file-preview-link {
+
   &::before {
     position: absolute;
     top: 50%;
@@ -73,19 +78,22 @@
     height: 50px;
     width: 50px;
     border-radius: 50%;
-    background-color: $black;
+    background-color: rgba($black, 0.6);
     color: $white;
     font-size: 24px;
     opacity: 0;
     content: "s";
     font-family: silverstripe;
     line-height: 27px;
+    z-index: 1;
+    transition: all .5s;
   }
 
+  &:hover,
   &:hover::before,
   &:active::before {
     text-decoration: none;
-    opacity: .6;
+    opacity: 1;
   }
 }
 
@@ -94,4 +102,6 @@
   max-height: $cms-panel-md * .75;
   min-height: 60px;
   margin: auto;
+  transform: scale(1);
+  transition: all .5s;
 }

--- a/client/src/containers/Editor/Editor.scss
+++ b/client/src/containers/Editor/Editor.scss
@@ -60,10 +60,11 @@
   display: block;
   align-items: center;
   text-decoration: none;
+}
 
+.editor__file-preview-link {
   &::before {
     position: absolute;
-    display: none;
     top: 50%;
     left: 50%;
     margin-top: -25px;
@@ -75,7 +76,7 @@
     background-color: $black;
     color: $white;
     font-size: 24px;
-    opacity: .6;
+    opacity: 0;
     content: "s";
     font-family: silverstripe;
     line-height: 27px;
@@ -84,8 +85,7 @@
   &:hover::before,
   &:active::before {
     text-decoration: none;
-    //display: block;
-    //cursor: pointer;
+    opacity: .6;
   }
 }
 

--- a/client/src/containers/Editor/Editor.scss
+++ b/client/src/containers/Editor/Editor.scss
@@ -105,3 +105,9 @@
   transform: scale(1);
   transition: all .5s;
 }
+
+.editor__file-preview-message--file-missing {
+  margin: #{$spacer-y * 2} 0 $spacer-y;
+  font-size: $font-size-lg;
+  color: $brand-danger;
+}

--- a/code/Forms/FileFormFactory.php
+++ b/code/Forms/FileFormFactory.php
@@ -120,6 +120,12 @@ class FileFormFactory extends AssetFormFactory
         if (!$markup) {
             return null;
         }
+        if (!$file->exists()) {
+            return sprintf('<div class="%s">%s</div>',
+                'editor__file-preview-message--file-missing',
+                _t('AssetAdmin.FILE_MISSING', 'File cannot be found')
+            );
+        }
         $link = $file->Link();
         $linkedImage = sprintf(
             '<a class="%s" href="%s" target="_blank">%s</a>',

--- a/code/Forms/FileFormFactory.php
+++ b/code/Forms/FileFormFactory.php
@@ -18,27 +18,6 @@ use SilverStripe\Forms\TextField;
 
 class FileFormFactory extends AssetFormFactory
 {
-
-    /**
-     * Get markdown for clickable link
-     *
-     * @param File $record
-     * @return string HTML markdown for link
-     */
-    protected function getClickableLinkMarkdown($record)
-    {
-        if (!$record || !$record->isInDB()) {
-            return null;
-        }
-        $link = $record->Link();
-        $clickableLink = sprintf(
-            '<i class="%1$s"></i><a href="%2$s" target="_blank">%2$s</a>',
-            'font-icon-link btn--icon-large form-control-static__icon',
-            Convert::raw2xml($link)
-        );
-        return $clickableLink;
-    }
-
     protected function getFormFieldTabs($record)
     {
         // Add extra tab
@@ -75,12 +54,7 @@ class FileFormFactory extends AssetFormFactory
             'Details',
             TextField::create("Title", File::singleton()->fieldLabel('Title')),
             TextField::create('Name', File::singleton()->fieldLabel('Filename')),
-            ReadonlyField::create("Path", _t('AssetTableField.PATH', 'Path'), $this->getPath($record)),
-            HTMLReadonlyField::create(
-                'ClickableURL',
-                _t('AssetTableField.URL', 'URL'),
-                $this->getClickableLinkMarkdown($record)
-            )
+            ReadonlyField::create("Path", _t('AssetTableField.PATH', 'Path'), $this->getPath($record))
         );
     }
 
@@ -133,6 +107,28 @@ class FileFormFactory extends AssetFormFactory
         $this->invokeWithExtensions('updateFormActions', $actions, $controller, $name, $context);
         return $actions;
     }
+    
+    /**
+     * Get raw HTML for image markup
+     *
+     * @param File $file
+     * @return string
+     */
+    protected function getIconMarkup($file)
+    {
+        $markup = parent::getIconMarkup($file);
+        if (!$markup) {
+            return null;
+        }
+        $link = $file->Link();
+        $linkedImage = sprintf(
+            '<a class="%s" href="%s" target="_blank">%s</a>',
+            'editor__file-preview-link',
+            $link,
+            $markup
+        );
+        return $linkedImage;
+    }
 
     /**
      * get HTML for status icon
@@ -165,7 +161,7 @@ class FileFormFactory extends AssetFormFactory
         }
         return null;
     }
-
+    
     /**
      * Get user-visible "Path" for this record
      *

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -10,6 +10,8 @@ en:
     ErrorItemPermissionDenied: 'It seems you don''t have the necessary permissions to add {ObjectTitle} to a campaign'
     ErrorNotFound: 'That {Type} couldn''t be found'
     Filetype: 'File type'
+    FILE_MISSING: 'File cannot be found'
+    MENUTITLE: Files
     NEWFOLDER: NewFolder
   AssetAdmin_DeleteBatchAction:
     TITLE: 'Delete folders'

--- a/tests/php/FileFormBuilderTest.php
+++ b/tests/php/FileFormBuilderTest.php
@@ -49,18 +49,14 @@ class FileFormBuilderTest extends SapphireTest
             '<div class="editor__specs">11 bytes <span class="editor__status-flag">Draft</span></div>',
             $fileSpecs
         );
-        $fileURL = $form->Fields()->fieldByName('Editor.Details.ClickableURL')->Value();
-        $this->assertEquals(
-            '<i class="font-icon-link btn--icon-large form-control-static__icon"></i>'
-            . '<a href="/assets/files/6adf67caca/testfile.txt" target="_blank">/assets/files/6adf67caca/testfile.txt</a>',
-            $fileURL
-        );
         $filePath = $form->Fields()->fieldByName('Editor.Details.Path')->Value();
         $this->assertEquals('files/', $filePath);
 
         $fileThumbnail = $form->Fields()->fieldByName('IconFull')->getContent();
         $this->assertEquals(
-            '<img src="framework/client/dist/images/app_icons/generic_32.png" class="editor__thumbnail" />',
+            '<a class="editor__file-preview-link" href="/assets/files/6adf67caca/testfile.txt" target="_blank">'.
+                '<img src="framework/client/dist/images/app_icons/generic_32.png" class="editor__thumbnail" />'.
+            '</a>',
             $fileThumbnail
         );
 
@@ -95,12 +91,6 @@ class FileFormBuilderTest extends SapphireTest
         $this->assertEquals(
             'files/',
             $form->Fields()->fieldByName('Editor.Details.Path')->dataValue()
-        );
-        $this->assertEquals(
-            '<i class="font-icon-link btn--icon-large form-control-static__icon"></i>'
-            . '<a href="/assets/files/6adf67caca/testfile.txt" target="_blank">'
-            . '/assets/files/6adf67caca/testfile.txt</a>',
-            $form->Fields()->fieldByName('Editor.Details.ClickableURL')->dataValue()
         );
 
         // Test actions


### PR DESCRIPTION
This gives a better feel for opening a file or large image in File editor, instead of a link field at the bottom of the form, the preview image/icon is a link and shows an open icon on hover.

Also fixed "Missing files" to show a message instead of an icon, this gives a stronger message that the file is missing.

More details https://github.com/silverstripe/silverstripe-asset-admin/issues/262