### PR TITLE
Remove additional spacing if no folders present

### DIFF
--- a/client/dist/styles/bundle.css
+++ b/client/dist/styles/bundle.css
@@ -237,25 +237,39 @@
 
 .gallery-item--draft,.gallery-item--modified{
   position:absolute;
-  top:.41027rem;
-  left:.6154rem;
+  top:.76925rem;
+  left:.76925rem;
   display:block;
-  width:13px;
-  height:13px;
-  border:1px solid #fff;
+  width:8px;
+  height:8px;
+  border:1px solid #f46b00;
+  box-shadow:0 0 1px .5px #fff;
   border-radius:100%;
+}
+
+.gallery-item--draft:hover:after,.gallery-item--modified:hover:after{
+  top:-4px;
+  font-size:10px;
+  font-weight:200;
+  position:absolute;
+  color:#fff;
+  margin-left:.9231rem;
 }
 
 .gallery-item--draft{
   background-color:#fff2e8;
 }
 
-.gallery-item--draft,.gallery-item--modified{
-  box-shadow:0 1px 1px rgba(0,0,0,.3),inset 0 0 0 2px #f46b00;
+.gallery-item--draft:hover:after{
+  content:"DRAFT";
 }
 
 .gallery-item--modified{
   background-color:#ff7f22;
+}
+
+.gallery-item--modified:hover:after{
+  content:"MODIFIED";
 }
 
 .bulk-actions{

--- a/client/dist/styles/bundle.css
+++ b/client/dist/styles/bundle.css
@@ -1,6 +1,5 @@
 .gallery-item{
   position:relative;
-  float:left;
   margin:0 1.2308rem 1.2308rem 0;
   background-color:#fff;
   border:1px solid;
@@ -424,6 +423,15 @@
   content:"g";
 }
 
+.asset-dropzone{
+  position:absolute;
+  left:0;
+  top:0;
+  right:0;
+  bottom:0;
+  margin:53px 1.5385rem 0;
+}
+
 .asset-dropzone:after{
   position:absolute;
   top:-70px;
@@ -456,17 +464,18 @@
   font-size:23px;
 }
 
-.gallery__folders{
-  margin-bottom:-6px;
-}
-
 .gallery__files,.gallery__folders{
-  display:inline-block;
-  width:100%;
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  -ms-flex-flow:row wrap;
+      flex-flow:row wrap;
 }
 
-.gallery__files{
-  margin-bottom:53px;
+@media (max-width:991px){
+  .gallery__files{
+    margin-bottom:53px;
+  }
 }
 
 .gallery__load{

--- a/client/dist/styles/bundle.css
+++ b/client/dist/styles/bundle.css
@@ -249,7 +249,7 @@
 
 .gallery-item--draft:hover:after,.gallery-item--modified:hover:after{
   top:-4px;
-  font-size:10px;
+  font-size:.769rem;
   font-weight:200;
   position:absolute;
   color:#fff;

--- a/client/src/components/AssetDropzone/AssetDropzone.scss
+++ b/client/src/components/AssetDropzone/AssetDropzone.scss
@@ -1,10 +1,10 @@
 .asset-dropzone {
-  // position: absolute;
-  // left: 0;
-  // top: 0;
-  // right: 0;
-  // bottom: 0;
-  // margin: $toolbar-total-height $grid-gutter-width-half 0;
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  margin: $toolbar-total-height $grid-gutter-width-half 0;
 
   &::after {
     position: absolute;

--- a/client/src/components/GalleryItem/GalleryItem.scss
+++ b/client/src/components/GalleryItem/GalleryItem.scss
@@ -2,7 +2,6 @@ $gallery-item-label-height: 40px;
 
 .gallery-item {
   position: relative;
-  float: left;
   margin: 0 $spacer-x $spacer-y 0;
   background-color: $white;
   border: 1px solid;

--- a/client/src/components/GalleryItem/GalleryItem.scss
+++ b/client/src/components/GalleryItem/GalleryItem.scss
@@ -258,7 +258,7 @@ $gallery-item-label-height: 40px;
 
   &:hover::after {
     top: -4px;
-    font-size: 10px;
+    font-size: $font-size-xxs;
     font-weight: 200;
     position: absolute;
     color: $white;

--- a/client/src/components/GalleryItem/GalleryItem.scss
+++ b/client/src/components/GalleryItem/GalleryItem.scss
@@ -247,21 +247,37 @@ $gallery-item-label-height: 40px;
 .gallery-item--draft,
 .gallery-item--modified {
   position: absolute;
-  top: ($spacer/3);
-  left: ($spacer/2);
+  top: $spacer-xs;
+  left: $spacer-xs;
   display: block;
-  width: $font-size-root;
-  height: $font-size-root;
-  border: 1px solid #fff;
+  width: 8px;
+  height: 8px;
+  border: 1px solid $state-draft;
+  box-shadow: 0 0 1px .5px $white;
   border-radius: 100%;
+
+  &:hover::after {
+    top: -4px;
+    font-size: 10px;
+    font-weight: 200;
+    position: absolute;
+    color: $white;
+    margin-left: $spacer-sm;
+  }
 }
 
 .gallery-item--draft {
-  background-color: #fff2e8;
-  box-shadow: 0 1px 1px rgba(0, 0, 0, .3), inset 0 0 0 2px #f46b00;
+  background-color: $state-draft-bg;
+
+  &:hover::after {
+    content: "DRAFT";
+  }
 }
 
 .gallery-item--modified {
-  background-color: #ff7f22;
-  box-shadow: 0 1px 1px rgba(0, 0, 0, .3), inset 0 0 0 2px #f46b00;
+  background-color: $state-modified-bg;
+
+  &:hover::after {
+    content: "MODIFIED";
+  }
 }

--- a/client/src/containers/Gallery/Gallery.scss
+++ b/client/src/containers/Gallery/Gallery.scss
@@ -23,16 +23,18 @@
   }
 }
 
-.gallery__folders {
-  display: inline-block;
-  margin-bottom: -6px;
-  width: 100%;
+.gallery__folders,
+.gallery__files {
+  display: flex;
+  flex-flow: row wrap;
 }
 
-.gallery__files {
-  display: inline-block;
-  width: 100%;
-  margin-bottom: $toolbar-total-height; // leave space at bottom for bulk-actions on smaller screens
+
+// leave space at bottom for bulk-actions on smaller screens
+@include media-breakpoint-down(md) {
+  .gallery__files {
+    margin-bottom: $toolbar-total-height;
+  }
 }
 
 .gallery__load {


### PR DESCRIPTION
Removes additional spacing above gallery items if there are no folders. 
I've swapped out the layout to flexbox which removes the additional spacing.
Also added updates to some missing variables for file states to match page states.

shows on hover of the little circle
![image](https://cloud.githubusercontent.com/assets/555033/19990278/704c5c70-a291-11e6-9dc1-07667a39b0c9.png)

Requires: https://github.com/silverstripe/silverstripe-framework/pull/6289
Fixes: https://github.com/silverstripe/silverstripe-asset-admin/issues/174


Was:
![pasted_image_4_11_16__12_33_pm](https://cloud.githubusercontent.com/assets/555033/19989375/ebbe2e4e-a28a-11e6-9ca4-42f0859a0be6.png)

New:
![pasted_image_4_11_16__12_32_pm](https://cloud.githubusercontent.com/assets/555033/19989359/ccf0db4c-a28a-11e6-9caf-327a4ed81875.png)
