### PR TITLE
Performance improvement to assets/api/readFolder

### DIFF
--- a/code/Controller/AssetAdmin.php
+++ b/code/Controller/AssetAdmin.php
@@ -228,7 +228,7 @@ class AssetAdmin extends LeftAndMain implements PermissionProvider
                     continue;
                 }
 
-                $items[] = $this->getObjectFromData($file);
+                $items[] = $this->getSortObjectFromData($file);
             }
         }
 
@@ -248,6 +248,7 @@ class AssetAdmin extends LeftAndMain implements PermissionProvider
             }
         }
 
+        // Sort the files        
         $column = 'title';
         $direction = 'asc';
         if (isset($params['sort'])) {
@@ -280,10 +281,16 @@ class AssetAdmin extends LeftAndMain implements PermissionProvider
             return 0;
         });
 
+        // Pageination
         $page = (isset($params['page'])) ? $params['page'] : 0;
         $limit = (isset($params['limit'])) ? $params['limit'] : $this->config()->page_length;
-        $filteredItems = array_slice($items, $page * $limit, $limit);
+        $toDisplay = array_slice($items, $page * $limit, $limit);
 
+        // Get the full details about the files to be displayed
+        $filteredItems = array_map(function ($item) {
+                return $this->getObjectFromData($item['file']);
+        }, $toDisplay);
+        
         // Build response
         $response = new HTTPResponse();
         $response->addHeader('Content-Type', 'application/json');
@@ -1068,6 +1075,21 @@ class AssetAdmin extends LeftAndMain implements PermissionProvider
         return $this->getRecordUpdatedResponse($record, $form);
     }
 
+    /**
+     * @param File $file
+     *
+     * @return array
+     */
+    protected function getSortObjectFromData(File $file)
+    {
+        return [
+            'file' => $file,
+            'created' => $file->Created,
+            'title' => $file->Title,
+            'type' => $file instanceof Folder ? 'folder' : $file->FileType,
+        ];
+    }
+    
     /**
      * @param File $file
      *

--- a/code/Controller/AssetAdmin.php
+++ b/code/Controller/AssetAdmin.php
@@ -248,7 +248,7 @@ class AssetAdmin extends LeftAndMain implements PermissionProvider
             }
         }
 
-        // Sort the files        
+        // Sort the files
         $column = 'title';
         $direction = 'asc';
         if (isset($params['sort'])) {


### PR DESCRIPTION
I have a few folders with 900+ images in them. This was the change I made to get reasonable performance in asset-admin. 

Only get the full details about a file after we have decided to return it.