### PR TITLE
Allow thumbnail=null in <GalleryItem>

### DIFF
--- a/client/dist/js/bundle.js
+++ b/client/dist/js/bundle.js
@@ -650,9 +650,8 @@ function t(e){o(this,t)
 var n=i(this,(t.__proto__||Object.getPrototypeOf(t)).call(this,e))
 return n.handleSelect=n.handleSelect.bind(n),n.handleActivate=n.handleActivate.bind(n),n.handleKeyDown=n.handleKeyDown.bind(n),n.handleCancelUpload=n.handleCancelUpload.bind(n),n.preventFocus=n.preventFocus.bind(n),
 n}return s(t,e),a(t,[{key:"handleActivate",value:function n(e){e.stopPropagation(),"function"==typeof this.props.onActivate&&this.props.onActivate(e,this.props.item)}},{key:"handleSelect",value:function r(e){
-e.stopPropagation(),e.preventDefault(),"function"==typeof this.props.onSelect&&this.props.onSelect(e,this.props.item)}},{key:"getThumbnailStyles",value:function l(){if(this.isImage()&&(this.exists()||this.uploading())){
-var e=this.props.item.thumbnail||this.props.item.url
-return{backgroundImage:"url("+e+")"}}return{}}},{key:"hasError",value:function p(){var p=!1
+e.stopPropagation(),e.preventDefault(),"function"==typeof this.props.onSelect&&this.props.onSelect(e,this.props.item)}},{key:"getThumbnailStyles",value:function l(){var e=this.props.item.thumbnail
+return this.isImage()&&e&&(this.exists()||this.uploading())?{backgroundImage:"url("+e+")"}:{}}},{key:"hasError",value:function p(){var p=!1
 return this.props.item.message&&(p="error"===this.props.item.message.type),p}},{key:"getErrorMessage",value:function d(){var e=null
 return this.hasError()?e=this.props.item.message.value:this.exists()||this.uploading()||(e=u["default"]._t("AssetAdmin.FILE_MISSING","File cannot be found")),null!==e?c["default"].createElement("span",{
 className:"gallery-item__error-message"},e):null}},{key:"getThumbnailClassNames",value:function h(){var e=["gallery-item__thumbnail"]

--- a/client/src/components/GalleryItem/GalleryItem.js
+++ b/client/src/components/GalleryItem/GalleryItem.js
@@ -46,8 +46,9 @@ class GalleryItem extends SilverStripeComponent {
    * @returns {Object}
    */
   getThumbnailStyles() {
-    if (this.isImage() && (this.exists() || this.uploading())) {
-      const thumbnail = this.props.item.thumbnail || this.props.item.url;
+    // Don't fall back to this.props.item.url since it might be huge
+    const thumbnail = this.props.item.thumbnail;
+    if (this.isImage() && thumbnail && (this.exists() || this.uploading())) {
       return {
         backgroundImage: `url(${thumbnail})`,
       };

--- a/client/src/components/GalleryItem/tests/GalleryItem-test.js
+++ b/client/src/components/GalleryItem/tests/GalleryItem-test.js
@@ -144,21 +144,30 @@ describe('GalleryItem', () => {
     let item = null;
 
     beforeEach(() => {
-      props.item.url = 'myurl';
-
       item = ReactTestUtils.renderIntoDocument(
         <GalleryItem {...props} />
       );
     });
 
-    it('should return backgroundImage with the correct url if the item is an image', () => {
+    it('should return backgroundImage with the correct url if the item is a thumbnail', () => {
       item.props.item.category = 'image';
+      item.props.item.url = 'myUrl';
+      item.props.item.thumbnail = 'myThumbnailUrl';
 
-      expect(JSON.stringify(item.getThumbnailStyles())).toBe('{"backgroundImage":"url(myurl)"}');
+      expect(JSON.stringify(item.getThumbnailStyles())).toBe('{"backgroundImage":"url(myThumbnailUrl)"}');
+    });
+
+    it('should not return backgroundImage with no thumbnail can be found', () => {
+      item.props.item.category = 'image';
+      item.props.item.url = 'myUrl';
+      item.props.item.thumbnail = '';
+
+      expect(JSON.stringify(item.getThumbnailStyles())).toBe('{}');
     });
 
     it('should return an empty object if the item is not an image', () => {
       item.props.item.category = 'notAnImage';
+      item.props.item.url = 'myUrl';
 
       expect(JSON.stringify(item.getThumbnailStyles())).toBe('{}');
     });


### PR DESCRIPTION
Sometimes the file exists, but is too large to resize due to PHP memory constraints.
Browsers use a crazy amount of memory to downsample a large CSS background-image,
so we can’t pass the original file instead of a thumbnail.

Required for https://github.com/silverstripe/silverstripe-framework/pull/6458