### PR TITLE
Fix position of the file insert button (fixes silverstripe/silverstripe-cms#1706)

### DIFF
--- a/client/dist/styles/bundle.css
+++ b/client/dist/styles/bundle.css
@@ -1447,7 +1447,7 @@ th.sort--disabled>span:after{
   background-color:#f6f7f8;
   z-index:2;
   position:absolute;
-  height:100%;
+  height:calc(100vh - 53px * 2);
   left:0;
 }
 
@@ -1470,6 +1470,29 @@ th.sort--disabled>span:after{
 .editor .nav-tabs{
   z-index:1;
   position:relative;
+}
+
+.panel--padded{
+  padding-bottom:0;
+}
+
+.panel--padded:after{
+  height:1.5385rem;
+  display:block;
+  content:"";
+}
+
+.panel--padded .editor__details form{
+  padding-bottom:0;
+}
+
+.panel--padded .editor__details .btn-toolbar{
+  margin-bottom:0;
+}
+
+.panel--padded .editor__details .fill-width{
+  -ms-flex-wrap:wrap;
+      flex-wrap:wrap;
 }
 
 .editor__heading{

--- a/client/src/containers/Editor/Editor.scss
+++ b/client/src/containers/Editor/Editor.scss
@@ -24,6 +24,32 @@
   }
 }
 
+.panel--padded {
+  padding-bottom: 0;
+
+  // Hack because firefox ignores bottom padding on scrolling containers
+  &:after {
+    height: 1.5385rem;
+    display: block;
+    content: "";
+  }
+
+  .editor__details {
+
+    form {
+      padding-bottom: 0;
+    }
+
+    .btn-toolbar {
+      margin-bottom: 0;
+    }
+
+    .fill-width {
+      flex-wrap: wrap;
+    }
+  }
+}
+
 .editor__heading {
   margin-right: $spacer-x * 2;
   white-space: nowrap;


### PR DESCRIPTION
Fixes [silverstripe/silverstripe-cms#1706](https://github.com/silverstripe/silverstripe-cms/issues/1706).
Tested on Chrome 55 and Firefox 50.1.

Uses a pseudo element instead of padding because Firefox ignores padding at the bottom of overflow containers.

Depends on #373 and #375 because the asset build is broken without them.