### PR TITLE
Updated abstract classname after GraphQL changes

### DIFF
--- a/code/GraphQL/ReadFileQueryCreator.php
+++ b/code/GraphQL/ReadFileQueryCreator.php
@@ -18,7 +18,7 @@ class ReadFileQueryCreator extends PaginatedQueryCreator
         ];
     }
 
-    public function connection()
+    public function createConnection()
     {
         return Connection::create('readFiles')
             ->setConnectionType(function () {


### PR DESCRIPTION
Changed connection() to createConnection() to match changes abstract method name on GraphQL module.