### PR TITLE
Fix editor panel is too large for smaller screens

### DIFF
--- a/client/dist/js/bundle.js
+++ b/client/dist/js/bundle.js
@@ -346,7 +346,7 @@ return!t.id||!e.props.files.find(function(e){return e.id===t.id})}).map(function
 highlighted:e.itemIsHighlighted(t.id)})}),o=this.props,i=o.type,a=o.loading,l=o.page,u=o.totalCount,p=o.limit,c=o.sort,f=o.selectedFiles,h=o.badges,m={selectableItems:"admin"===i,files:r,loading:a,page:l,
 totalCount:u,limit:p,sort:c,selectedFiles:f,badges:h,onSort:this.handleSort,onSetPage:this.handleSetPage,onOpenFile:this.handleOpenFile,onOpenFolder:this.handleOpenFolder,onSelect:this.handleSelect,onCancelUpload:this.handleCancelUpload,
 onDropFiles:this.handleMoveFiles,onRemoveErroredUpload:this.handleRemoveErroredUpload,onEnableDropzone:this.handleEnableDropzone}
-return w["default"].createElement(t,m)}},{key:"render",value:function le(){if(!this.props.folder)return this.props.errorMessage?w["default"].createElement("div",{className:"flexbox-area-grow gallery__error"
+return w["default"].createElement(t,m)}},{key:"render",value:function le(){if(!this.props.folder)return this.props.errorMessage?w["default"].createElement("div",{className:"gallery__error flexbox-area-grow"
 },w["default"].createElement("div",{className:"gallery__error-message"},w["default"].createElement("h3",null,C["default"]._t("AssetAdmin.DROPZONE_RESPONSE_ERROR","Server responded with an error.")),w["default"].createElement("p",null,this.props.errorMessage))):w["default"].createElement("div",{
 className:"flexbox-area-grow"})
 var e=w["default"].createElement("div",{className:"gallery_messages"},this.props.errorMessage&&w["default"].createElement(G["default"],{value:this.props.errorMessage,type:"danger"}),this.props.noticeMessage&&w["default"].createElement(G["default"],{

--- a/client/dist/styles/bundle.css
+++ b/client/dist/styles/bundle.css
@@ -1417,16 +1417,17 @@
   background-color:#f6f7f8;
   z-index:2;
   position:absolute;
-  height:calc(100% - 53px);
+  height:100%;
   left:0;
 }
 
 @media (min-width:992px){
   .editor{
-    box-sizing:content-box;
     width:300px;
     border-left:1px solid #d9dee2;
     position:relative;
+    height:100%;
+    padding-bottom:0;
   }
 }
 
@@ -1439,14 +1440,6 @@
 .editor .nav-tabs{
   z-index:1;
   position:relative;
-}
-
-.editor__details{
-  margin-bottom:2.4616rem;
-}
-
-.editor__details .form-group:after{
-  margin-bottom:1.2308rem;
 }
 
 .editor__heading{
@@ -1563,13 +1556,6 @@
 .relative-time[title]{
   cursor:pointer;
   text-decoration:underline;
-}
-
-@media (max-width:1199px){
-  .editor{
-    height:100%;
-    padding-bottom:0;
-  }
 }
 
 .insert-media-modal .modal-lg{

--- a/client/dist/styles/bundle.css
+++ b/client/dist/styles/bundle.css
@@ -1417,7 +1417,7 @@
   background-color:#f6f7f8;
   z-index:2;
   position:absolute;
-  height:calc(100vh - 53px);
+  height:calc(100% - 53px);
   left:0;
 }
 

--- a/client/src/containers/Editor/Editor.scss
+++ b/client/src/containers/Editor/Editor.scss
@@ -2,14 +2,15 @@
   background-color: $body-bg;
   z-index: 2;
   position: absolute;
-  height: calc(100% - #{$toolbar-total-height}); // Safari fix for scroll, should be better fix
+  height: 100%; // Safari fix for scroll, should be better fix
   left: 0;
 
   @include media-breakpoint-up(lg) {
-    box-sizing: content-box;
     width: $cms-panel-sm;
     border-left: 1px solid $border-color;
     position: relative;
+    height: 100%;
+    padding-bottom: 0;
   }
 
   @include media-breakpoint-up(xl) {
@@ -20,14 +21,6 @@
   .nav-tabs {
     z-index: 1;
     position: relative;
-  }
-}
-
-.editor__details {
-  margin-bottom: $spacer-y * 2;
-
-  .form-group::after {
-    margin-bottom: $spacer-y;
   }
 }
 
@@ -145,11 +138,4 @@
 .relative-time[title] {
   cursor: pointer;
   text-decoration: underline;
-}
-
-@include media-breakpoint-down(lg) {
-  .editor {
-    height: 100%;
-    padding-bottom: 0;
-  }
 }

--- a/client/src/containers/Editor/Editor.scss
+++ b/client/src/containers/Editor/Editor.scss
@@ -2,7 +2,7 @@
   background-color: $body-bg;
   z-index: 2;
   position: absolute;
-  height: calc(100vh - #{$toolbar-total-height}); // Safari fix for scroll, should be better fix
+  height: calc(100% - #{$toolbar-total-height}); // Safari fix for scroll, should be better fix
   left: 0;
 
   @include media-breakpoint-up(lg) {

--- a/client/src/containers/Gallery/Gallery.js
+++ b/client/src/containers/Gallery/Gallery.js
@@ -828,7 +828,7 @@ class Gallery extends Component {
     if (!this.props.folder) {
       if (this.props.errorMessage) {
         return (
-          <div className="flexbox-area-grow gallery__error">
+          <div className="gallery__error flexbox-area-grow">
             <div className="gallery__error-message">
               <h3>
                 { i18n._t('AssetAdmin.DROPZONE_RESPONSE_ERROR', 'Server responded with an error.') }


### PR DESCRIPTION
And fixed "Gallery" area when it is loading or errors. (Editor no longer floats in the centre)

I've changed from `100vh` to `100%` because the modal may not necessarily have 100% view height.

Fixes https://github.com/silverstripe/silverstripe-cms/issues/1706