### PR TITLE
Remove flexbox class from Dimensions field group

### DIFF
--- a/code/Forms/ImageFormFactory.php
+++ b/code/Forms/ImageFormFactory.php
@@ -57,7 +57,7 @@ class ImageFormFactory extends FileFormFactory
                 )
                     ->setMaxLength(5)
                     ->addExtraClass('flexbox-area-grow')
-            )->addExtraClass('fill-width')
+            )->addExtraClass('fieldgroup--fill-width')
         );
 
         $tab->insertBefore(


### PR DESCRIPTION
Fix for this is https://github.com/silverstripe/silverstripe-framework/pull/6656

Removing flexbox class ".fill-width" for a bit of nested css.
This is because `addExtraClass` is added to the container and the field-holder...