### PR TITLE
API Update to use new CMS form route handler

### DIFF
--- a/code/Forms/AssetFormFactory.php
+++ b/code/Forms/AssetFormFactory.php
@@ -46,6 +46,12 @@ abstract class AssetFormFactory implements FormFactory
         $this->constructExtensions();
     }
 
+    /**
+     * @param Controller $controller
+     * @param string $name
+     * @param array $context
+     * @return Form
+     */
     public function getForm(Controller $controller, $name = FormFactory::DEFAULT_NAME, $context = [])
     {
         // Validate context
@@ -70,7 +76,7 @@ abstract class AssetFormFactory implements FormFactory
 
         return $form;
     }
-    
+
     /**
      * Get the validator for the form to be built
      *
@@ -82,7 +88,7 @@ abstract class AssetFormFactory implements FormFactory
     protected function getValidator(Controller $controller, $formName, $context = [])
     {
         $validator = new RequiredFields('Name');
-        
+
         return $validator;
     }
 
@@ -101,6 +107,7 @@ abstract class AssetFormFactory implements FormFactory
      * Gets the main tabs for the file edit form
      *
      * @param File $record
+     * @param array $context
      * @return TabSet
      */
     protected function getFormFieldTabs($record, $context = [])
@@ -139,7 +146,7 @@ abstract class AssetFormFactory implements FormFactory
         }
         return null;
     }
-    
+
     /**
      * @param Controller $controller
      * @param $formName
@@ -195,7 +202,7 @@ abstract class AssetFormFactory implements FormFactory
         $this->invokeWithExtensions('updateFormFields', $fields, $controller, $formName, $context);
         return $fields;
     }
-    
+
     /**
      * Build popup menu
      *
@@ -216,11 +223,11 @@ abstract class AssetFormFactory implements FormFactory
         }
         return null;
     }
-    
+
     /**
      * Get actions that go into the Popover menu
      *
-     * @param $record
+     * @param File $record
      * @return array
      */
     protected function getPopoverActions($record)
@@ -229,7 +236,7 @@ abstract class AssetFormFactory implements FormFactory
             $this->getDeleteAction($record)
         ]);
     }
-    
+
     /**
      * Build "details" formfield tab
      *

--- a/code/Forms/FolderCreateFormFactory.php
+++ b/code/Forms/FolderCreateFormFactory.php
@@ -15,7 +15,7 @@ class FolderCreateFormFactory extends FolderFormFactory
     {
         return ['ParentID'];
     }
-    
+
     public function getFormFields(Controller $controller, $name, $context = [])
     {
         // Add status flag before extensions are triggered
@@ -35,15 +35,17 @@ class FolderCreateFormFactory extends FolderFormFactory
                     ->addExtraClass('editor__file-preview--folder')
             );
             $fields->push(HiddenField::create('ParentID', null, $context['ParentID']));
-            
+
             $title = $fields->fieldByName('TitleHeader');
-            $titleNew = _t('AssetAdmin.NewFile', 'New {file}', [ 'file' => Folder::config()->singular_name ]);
+            $titleNew = _t('AssetAdmin.NewFile', 'New {file}', [
+                'file' => Folder::singleton()->i18n_singular_name()
+            ]);
             $title->setTitle($titleNew);
         });
-    
+
         return parent::getFormFields($controller, $name, $context);
     }
-    
+
     /**
      * @param File $record
      * @return FormAction
@@ -54,7 +56,7 @@ class FolderCreateFormFactory extends FolderFormFactory
             ->setIcon('plus-circled')
             ->setSchemaData(['data' => ['buttonStyle' => 'primary']]);
     }
-    
+
     /**
      * @param File $record
      * @return null

--- a/code/Forms/ImageFormFactory.php
+++ b/code/Forms/ImageFormFactory.php
@@ -2,8 +2,6 @@
 
 namespace SilverStripe\AssetAdmin\Forms;
 
-use SilverStripe\Assets\File;
-use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldGroup;
 use SilverStripe\Forms\Tab;
@@ -11,7 +9,6 @@ use SilverStripe\Forms\TextField;
 
 class ImageFormFactory extends FileFormFactory
 {
-
     protected function getSpecsMarkup($record)
     {
         if (!$record || !$record->exists()) {

--- a/code/Forms/PreviewImageField.php
+++ b/code/Forms/PreviewImageField.php
@@ -14,7 +14,7 @@ use SilverStripe\ORM\DataObject;
 class PreviewImageField extends FormField
 {
     /**
-     * @var Integer
+     * @var int
      */
     protected $recordID = null;
 

--- a/code/Forms/RemoteFileFormFactory.php
+++ b/code/Forms/RemoteFileFormFactory.php
@@ -14,13 +14,10 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\FormFactory;
-use SilverStripe\Forms\HeaderField;
 use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField_Embed;
-use SilverStripe\Forms\LabelField;
 use SilverStripe\Forms\LiteralField;
 use SilverStripe\Forms\OptionsetField;
-use SilverStripe\Forms\ReadonlyField;
 use SilverStripe\Forms\RequiredFields;
 use SilverStripe\Forms\TextField;
 


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-cms/issues/1510

Allows formfield actions to work in ReactJS forms. Required for https://github.com/silverstripe/silverstripe-framework/issues/6141