### PR TITLE
FIX jquery case-sensitivity issue with dropzone

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,6 +57,7 @@ module.exports = {
     'graphql-tag': 'GraphQLTag',
     i18n: 'i18n',
     jquery: 'jQuery',
+    jQuery: 'jQuery',
     'lib/Backend': 'Backend',
     'lib/Config': 'Config',
     'lib/Injector': 'Injector',


### PR DESCRIPTION
When I run `yarn watch` I was getting the following error:

```
ERROR in ./~/dropzone/dist/dropzone.js
Module not found: Error: Cannot resolve module 'jQuery' in /home/micmania1/projects/ss4/asset-admin/node_modules/dropzone/dist
 @ ./~/dropzone/dist/dropzone.js 1:0-17
```