### PR TITLE
Fix asset editor height in Safari browser

### DIFF
--- a/client/dist/styles/bundle.css
+++ b/client/dist/styles/bundle.css
@@ -1629,7 +1629,6 @@ th.sort--disabled>span:after{
     width:300px;
     border-left:1px solid #d9dee2;
     position:relative;
-    height:100%;
     padding-bottom:0;
   }
 }
@@ -1643,6 +1642,12 @@ th.sort--disabled>span:after{
 .editor .nav-tabs{
   z-index:1;
   position:relative;
+}
+
+.editor .editor__details{
+  height:calc(100vh - 53px);
+  -webkit-transform:translateZ(0);
+          transform:translateZ(0);
 }
 
 .editor__heading{
@@ -1783,6 +1788,10 @@ th.sort--disabled>span:after{
 .insert-media-modal .modal-body{
   padding:0;
   height:100%;
+}
+
+.insert-media-modal .editor__details{
+  height:calc(100vh - 106px);
 }
 
 @media (min-width:992px){

--- a/client/src/containers/Editor/Editor.scss
+++ b/client/src/containers/Editor/Editor.scss
@@ -9,7 +9,6 @@
     width: $cms-panel-sm;
     border-left: 1px solid $border-color;
     position: relative;
-    height: 100%;
     padding-bottom: 0;
   }
 
@@ -21,6 +20,11 @@
   .nav-tabs {
     z-index: 1;
     position: relative;
+  }
+
+  .editor__details {
+    height: calc(100vh - #{$toolbar-total-height}); // Height fix in Safari
+    transform: translateZ(0); // Safari fix - form fields are not visible intermittently
   }
 }
 

--- a/client/src/containers/InsertMediaModal/InsertMediaModal.scss
+++ b/client/src/containers/InsertMediaModal/InsertMediaModal.scss
@@ -21,6 +21,11 @@
     height: 100%;
   }
 
+  // If the editor is in the dialog
+  .editor__details {
+    height: calc(100vh - #{$toolbar-total-height * 2}); // Safari fix for scroll, should be better fix
+  }
+
   @include media-breakpoint-up(lg) {
     .btn--close-panel {
       display: none;


### PR DESCRIPTION
Issue: https://github.com/silverstripe/silverstripe-asset-admin/issues/448

Tested on: Chrome, Firefox, Safari, and IE 11.