### PR TITLE
Fix remove position absolute from close button

### DIFF
--- a/client/dist/styles/bundle.css
+++ b/client/dist/styles/bundle.css
@@ -1751,7 +1751,6 @@ th.sort--disabled>span:after{
     float:left;
     right:auto;
     margin-right:0;
-    position:absolute;
     margin-left:-15px;
     color:#66727d;
   }

--- a/client/src/containers/Editor/Editor.scss
+++ b/client/src/containers/Editor/Editor.scss
@@ -130,7 +130,6 @@
     float: left;
     right: auto;
     margin-right: 0;
-    position: absolute;
     margin-left: -15px;
     color: $body-color-light;
 


### PR DESCRIPTION
Fixes the close button so that it doesn't stay on screen even when scroll down the Editor
![screen shot 2017-04-28 at 10 23 29 am](https://cloud.githubusercontent.com/assets/1064889/25507275/15ed7a64-2bff-11e7-804d-4a400698f043.png)
