### PR TITLE
Fix shifted positioning for Search in IE and helps breadcrumbs ellipsis

### DIFF
--- a/client/dist/styles/bundle.css
+++ b/client/dist/styles/bundle.css
@@ -847,9 +847,7 @@
 }
 
 .search{
-  position:absolute;
-  top:0;
-  right:1.5385rem;
+  margin-right:1.5385rem;
 }
 
 @media (min-width:768px){
@@ -859,12 +857,12 @@
   }
 
   .search.search--active{
-    position:relative;
     right:0;
   }
 }
 
 .search.search--active{
+  position:relative;
   width:calc(100% - 1.5385rem);
 }
 

--- a/client/src/components/Search/Search.scss
+++ b/client/src/components/Search/Search.scss
@@ -1,21 +1,19 @@
 // AssetAdmin search
 
 .search {
-  position: absolute;
-  top: 0;
-  right: $panel-padding-x;
+  margin-right: $panel-padding-x;
 
   @include media-breakpoint-up(md) {
     position: relative;
     right: auto;
 
     &.search--active {
-      position: relative;
       right: 0;
     }
   }
 
   &.search--active {
+    position: relative;
     width: calc(100% - #{$panel-padding-x});
   }
 }


### PR DESCRIPTION
Removes position absolutes and position relatives, until Search is opened.
This is so breadcrumbs can then ellipsis cleanly by using flexbox