### PR TITLE
Remove `cms` and `campaign-admin` dependencies.

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -34,3 +34,11 @@ After:
 SilverStripe\Core\Injector\Injector:
   SilverStripe\Forms\FileHandleField:
     class: SilverStripe\AssetAdmin\Forms\UploadField
+
+---
+Only:
+  moduleexists: 'silverstripe/campaign-admin'
+---
+SilverStripe\AssetAdmin\Forms\FileFormFactory:
+  extensions:
+    - 'SilverStripe\AssetAdmin\Extensions\CampaignAdminExtension'

--- a/code/Extensions/CampaignAdminExtension.php
+++ b/code/Extensions/CampaignAdminExtension.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SilverStripe\AssetAdmin\Extensions;
+
+use SilverStripe\Assets\File;
+use SilverStripe\Core\Extension;
+use SilverStripe\Forms\FormAction;
+
+/**
+ * Extension that updates the Popover menu of `FileFormFactory`.
+ * This extension will only be applied if the `campaign-admin` module is installed.
+ * @package SilverStripe\AssetAdmin\Extensions
+ */
+class CampaignAdminExtension extends Extension
+{
+    /**
+     * Update the Popover menu of `FileFormFactory` with the "Add to campaign" button.
+     *
+     * @param array $actions
+     * @param File $record
+     */
+    public function updatePopoverActions(&$actions, $record)
+    {
+        if ($record && $record->canPublish()) {
+            array_unshift($actions, FormAction::create(
+                'addtocampaign',
+                _t('SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.ADDTOCAMPAIGN', 'Add to campaign')
+            ));
+        }
+    }
+}

--- a/code/Forms/AssetFormFactory.php
+++ b/code/Forms/AssetFormFactory.php
@@ -218,6 +218,7 @@ abstract class AssetFormFactory implements FormFactory
         if ($popoverActions) {
             return PopoverField::create($popoverActions)
                 ->setPlacement('top')
+                ->setName('PopoverActions')
                 ->setButtonTooltip(_t(
                     'SilverStripe\\AssetAdmin\\Forms\\FileFormFactory.OTHER_ACTIONS',
                     'Other actions'
@@ -234,9 +235,12 @@ abstract class AssetFormFactory implements FormFactory
      */
     protected function getPopoverActions($record)
     {
-        return array_filter([
+        $actions = [
             $this->getDeleteAction($record)
-        ]);
+        ];
+
+        $this->invokeWithExtensions('updatePopoverActions', $actions, $record);
+        return array_filter($actions);
     }
 
     /**

--- a/code/Forms/FileFormFactory.php
+++ b/code/Forms/FileFormFactory.php
@@ -232,23 +232,6 @@ class FileFormFactory extends AssetFormFactory
     }
 
     /**
-     * Get action for adding to campaign
-     *
-     * @param File $record
-     * @return FormAction|null
-     */
-    protected function getAddToCampaignAction($record)
-    {
-        if ($record && $record->canPublish()) {
-            return FormAction::create(
-                'addtocampaign',
-                _t('SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.ADDTOCAMPAIGN', 'Add to campaign')
-            );
-        }
-        return null;
-    }
-
-    /**
      * Get action for publishing
      *
      * @param File $record
@@ -269,7 +252,7 @@ class FileFormFactory extends AssetFormFactory
         return FormAction::create('unpublish', $unpublishText)
             ->setIcon('cancel-circled');
     }
-    
+
     /**
      * Get actions that go into the Popover menu
      *
@@ -278,11 +261,12 @@ class FileFormFactory extends AssetFormFactory
      */
     protected function getPopoverActions($record)
     {
-        return array_filter([
-            $this->getAddToCampaignAction($record),
-            $this->getUnpublishAction($record),
-            $this->getDeleteAction($record)
-        ]);
+        $this->beforeExtending('updatePopoverActions', function (&$actions, $record) {
+            // add the unpublish action to the start of the array
+            array_unshift($actions, $this->getUnpublishAction($record));
+        });
+
+        return parent::getPopoverActions($record);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,8 @@
   "type": "silverstripe-module",
   "license": "BSD-3-Clause",
   "require": {
-    "silverstripe/cms": "^4@dev",
+    "silverstripe/admin": "^1.0@dev",
     "silverstripe/framework": "^4@dev",
-    "silverstripe/campaign-admin": "^1@dev",
     "silverstripe/graphql": "^0.2@dev"
   },
   "require-dev": {
@@ -14,6 +13,8 @@
     "silverstripe/behat-extension": "^2.1.0",
     "silverstripe/serve": "dev-master",
     "silverstripe/testsession": "^2.0.0-alpha3",
+    "silverstripe/cms": "^4@dev",
+    "silverstripe/campaign-admin": "^1@dev",
     "se/selenium-server-standalone": "2.41.0"
   },
   "extra": {

--- a/tests/php/Forms/FileFormBuilderTest/FileExtension.php
+++ b/tests/php/Forms/FileFormBuilderTest/FileExtension.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SilverStripe\AssetAdmin\Tests\Forms\FileFormBuilderTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataExtension;
+
+/**
+ * An extension to test file permissions
+ * @package SilverStripe\AssetAdmin\Tests\Forms\FileFormBuilderTest
+ */
+class FileExtension extends DataExtension implements TestOnly
+{
+    // public flags to toggle permissions during tests
+    public static $canDelete = false;
+    public static $canPublish = true;
+    public static $canUnpublish = true;
+
+    public function canDelete($member)
+    {
+        return self::$canDelete;
+    }
+
+    public function canPublish($member = null)
+    {
+        return self::$canPublish;
+    }
+
+    public function canUnpublish($member = null)
+    {
+        return self::$canUnpublish;
+    }
+}


### PR DESCRIPTION
Add `admin` dependency instead.
Add form-button that is specific to `campaign-admin` via an extension that is only applied when that module is present.
Explicitly set the popover actions field name for easier targeting in extensions and tests.
Updated unit-tests (test form fields with- and without extension applied).

Fixes #450 