### PR TITLE
Revert "Change asset admin gallery thumbnail to contain image"

### DIFF
--- a/client/dist/styles/bundle.css
+++ b/client/dist/styles/bundle.css
@@ -63,7 +63,7 @@
   margin:0 auto;
   background-repeat:no-repeat;
   background-position:50%;
-  background-size:contain;
+  background-size:cover;
   border-radius:.2rem .2rem 0 0;
 }
 

--- a/client/src/components/GalleryItem/GalleryItem.scss
+++ b/client/src/components/GalleryItem/GalleryItem.scss
@@ -65,7 +65,7 @@ $gallery-item-label-height: 40px;
   margin: 0 auto;
   background-repeat: no-repeat;
   background-position: center center;
-  background-size: contain;
+  background-size: cover;
   border-radius: $border-radius-sm $border-radius-sm 0 0;
 }
 


### PR DESCRIPTION
This reverts commit d431b8bb83c30377c9a65ca9939b49140f793aa1.
See https://github.com/silverstripe/silverstripe-asset-admin/issues/434#issuecomment-300346479