### PR TITLE
BUG Fix bad image url

### DIFF
--- a/code/Model/EmbedResource.php
+++ b/code/Model/EmbedResource.php
@@ -59,8 +59,8 @@ class EmbedResource
         }
 
         // Default media
-        return ModuleLoader::getModule('silverstripe/admin')
-            ->getResourcePath('client/dist/images/src/default_media.png');
+        return ModuleLoader::getModule('silverstripe/asset-admin')
+            ->getResourceURL('client/dist/images/icon_file.png');
     }
 
     /**


### PR DESCRIPTION
getResourcePath() returns the full filesystem path, which isn't correct in any case.

The file it was pointing to has since been removed, so it was a broken link anyway.