### PR TITLE
FIX Update translations from "only these people" to "only these groups" to match CMS

### DIFF
--- a/code/Forms/AssetFormFactory.php
+++ b/code/Forms/AssetFormFactory.php
@@ -162,7 +162,7 @@ abstract class AssetFormFactory implements FormFactory
                         'dirtyClass' => '',
                     ],
                 ]);
-            
+
             return $action;
         }
         return null;
@@ -349,7 +349,7 @@ abstract class AssetFormFactory implements FormFactory
             'Inherit' => _t(__CLASS__.'.INHERIT', 'Inherit from parent folder'),
             'Anyone' => _t(__CLASS__.'.ANYONE', 'Anyone'),
             'LoggedInUsers' => _t(__CLASS__.'.LOGGED_IN', 'Logged-in users'),
-            'OnlyTheseUsers' => _t(__CLASS__.'.ONLY_GROUPS', 'Only these people (choose from list)')
+            'OnlyTheseUsers' => _t(__CLASS__.'.ONLY_GROUPS', 'Only these groups (choose from list)')
         ];
 
         // No "Anyone" editors option

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -56,7 +56,7 @@ en:
     FOLDERLOCATION: 'Folder location'
     INHERIT: 'Inherit from parent folder'
     LOGGED_IN: 'Logged-in users'
-    ONLY_GROUPS: 'Only these people (choose from list)'
+    ONLY_GROUPS: 'Only these groups (choose from list)'
     ROOTNAME: '(Top level)'
     VIEWERGROUPS: 'Viewer Groups'
   SilverStripe\AssetAdmin\Forms\FileFormFactory:

--- a/tests/behat/features/manage-file-permissions.feature
+++ b/tests/behat/features/manage-file-permissions.feature
@@ -20,7 +20,7 @@ Feature: Manage file permissions
     When I press the "Edit" button
     Then I should see the "Form_fileEditForm" form
     When I click "Permissions" in the "#Editor .nav-tabs" element
-      And I select "Only these people (choose from list)" from "Who can edit this file?" input group
+      And I select "Only these groups (choose from list)" from "Who can edit this file?" input group
       And I select "ADMIN group" in the "#Form_fileEditForm_EditorGroups_Holder" tree dropdown
       And I press the "Save" button
       And I am not logged in
@@ -40,7 +40,7 @@ Feature: Manage file permissions
     When I press the "Edit" button
     Then I should see the "Form_fileEditForm" form
     When I click "Permissions" in the "#Editor .nav-tabs" element
-      And I select "Only these people (choose from list)" from "Who can edit this file?" input group
+      And I select "Only these groups (choose from list)" from "Who can edit this file?" input group
       And I select "EDITOR group" in the "#Form_fileEditForm_EditorGroups_Holder" tree dropdown
       And I press the "Save" button
       And I am not logged in


### PR DESCRIPTION
We updated "only these people" to "only these groups" in the CMS and siteconfig with PRs like https://github.com/silverstripe/silverstripe-cms/pull/1880, this updates that as well.