### PR TITLE
Fix made updating the file Class representation for an extension less aggressive

### DIFF
--- a/code/Controller/AssetAdmin.php
+++ b/code/Controller/AssetAdmin.php
@@ -1050,8 +1050,15 @@ class AssetAdmin extends LeftAndMain implements PermissionProvider
             $extension = File::get_file_extension($data['FileFilename']);
             $newClass = File::get_class_for_file_extension($extension);
 
-            // if the class has changed, cast it to the proper class
-            if ($record->getClassName() !== $newClass) {
+            // If the file extension has changed, change to the proper new class which represents it.
+            // The class will not change if the current class is a subclass of the new class.
+            // An exception is if new class is the generic File::class - to not change to the generic
+            // File::class make sure to register the file extension and your class to config in
+            // File::class_for_file_extension
+            $currentClass = $record->getClassName();
+            if (!is_a($currentClass, $newClass, true) ||
+                ($currentClass !== $newClass && $newClass === File::class)
+            ) {
                 $record = $record->newClassInstance($newClass);
 
                 // update the allowed category for the new file extension


### PR DESCRIPTION
This means it allows for subclasses of registered file extensions - e.g. `MyImage` extends `Image`, then if you save that file it will retain the class `MyImage` and not change to `Image`

A caveat is if you've added a `PDFFile` class which extends `File`, it will need to be registered to `File::class_for_file_extension` in order for that file to not be changed back to `File` on save and also mean that all `*.pdf` files uploaded will be of that class.

Fixes https://github.com/silverstripe/silverstripe-asset-admin/issues/539