### PR TITLE
Expose as vendor module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ env:
     - DISPLAY=":99"
     - XVFBARGS=":99 -ac -screen 0 1024x768x16"
     - TRAVIS_NODE_VERSION="6"
+    - SS_BASE_URL="http://localhost:8080/"
+    - SS_ENVIRONMENT_TYPE="dev"
 
 matrix:
   include:
@@ -45,11 +47,10 @@ before_script:
   - composer update
   - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
 # Start behat services
-  - if [[ $BEHAT_TEST ]]; then echo 'SS_BASE_URL=http://localhost:8080/' >> .env; fi
   - if [[ $BEHAT_TEST ]]; then mkdir artifacts; fi
   - if [[ $BEHAT_TEST ]]; then sh -e /etc/init.d/xvfb start; sleep 3; fi
   - if [[ $BEHAT_TEST ]]; then (vendor/bin/selenium-server-standalone > artifacts/selenium.log 2>&1 &); fi
-  - if [[ $BEHAT_TEST ]]; then (vendor/bin/serve --bootstrap-file cms/tests/behat/serve-bootstrap.php &> artifacts/serve.log &); fi
+  - if [[ $BEHAT_TEST ]]; then (vendor/bin/serve --bootstrap-file vendor/silverstripe/cms/tests/behat/serve-bootstrap.php &> artifacts/serve.log &); fi
 
 # Install NPM dependencies
   - if [[ $NPM_TEST ]]; then nvm install $TRAVIS_NODE_VERSION && nvm use $TRAVIS_NODE_VERSION && npm install -g yarn && yarn install --network-concurrency 1 && (cd silverstripe-admin && yarn install --network-concurrency 1) && yarn run build; fi
@@ -64,4 +65,4 @@ script:
   - if [[ $PHPCS_TEST ]]; then composer run-script lint; fi
 
 after_failure:
-  - php ./framework/tests/behat/travis-upload-artifacts.php --if-env BEHAT_TEST,ARTIFACTS_BUCKET,ARTIFACTS_KEY,ARTIFACTS_SECRET --target-path $TRAVIS_REPO_SLUG/$TRAVIS_BUILD_ID/$TRAVIS_JOB_ID --artifacts-base-url https://s3.amazonaws.com/$ARTIFACTS_BUCKET/ --artifacts-path ./artifacts/
+  - php ./vendor/silverstripe/framework/tests/behat/travis-upload-artifacts.php --if-env BEHAT_TEST,ARTIFACTS_BUCKET,ARTIFACTS_KEY,ARTIFACTS_SECRET --target-path $TRAVIS_REPO_SLUG/$TRAVIS_BUILD_ID/$TRAVIS_JOB_ID --artifacts-base-url https://s3.amazonaws.com/$ARTIFACTS_BUCKET/ --artifacts-path ./artifacts/

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ before_script:
   - if [[ $BEHAT_TEST ]]; then (vendor/bin/serve --bootstrap-file vendor/silverstripe/cms/tests/behat/serve-bootstrap.php &> artifacts/serve.log &); fi
 
 # Install NPM dependencies
-  - if [[ $NPM_TEST ]]; then nvm install $TRAVIS_NODE_VERSION && nvm use $TRAVIS_NODE_VERSION && npm install -g yarn && yarn install --network-concurrency 1 && (cd silverstripe-admin && yarn install --network-concurrency 1) && yarn run build; fi
+  - if [[ $NPM_TEST ]]; then nvm install $TRAVIS_NODE_VERSION && nvm use $TRAVIS_NODE_VERSION && npm install -g yarn && yarn install --network-concurrency 1 && (cd vendor/silverstripe/admin && yarn install --network-concurrency 1) && yarn run build; fi
 
 script:
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit tests/php; fi

--- a/_config.php
+++ b/_config.php
@@ -1,23 +1,18 @@
 <?php
 
+use SilverStripe\Core\Manifest\ModuleLoader;
 use SilverStripe\Forms\HTMLEditor\TinyMCEConfig;
 
 // Avoid creating global variables
 call_user_func(function () {
-    if (strcasecmp(__DIR__, BASE_PATH) === 0) {
-        // Admin is root
-        $clientPath = 'client';
-    } else {
-        // Asset-admin is subdir
-        $clientPath = basename(__DIR__) . '/client';
-    }
+    $module = ModuleLoader::inst()->getManifest()->getModule('silverstripe/asset-admin');
 
     // Re-enable media dialog
     $config = TinyMCEConfig::get('cms');
     $config->enablePlugins([
-        'ssmedia' => "{$clientPath}/dist/js/TinyMCE_ssmedia.js",
-        'ssembed' => "{$clientPath}/dist/js/TinyMCE_ssembed.js",
-        'sslinkfile' => "{$clientPath}/dist/js/TinyMCE_sslink-file.js",
+        'ssmedia' => $module->getResource('client/dist/js/TinyMCE_ssmedia.js')->getURL(),
+        'ssembed' => $module->getResource('client/dist/js/TinyMCE_ssembed.js')->getURL(),
+        'sslinkfile' => $module->getResource('client/dist/js/TinyMCE_sslink-file.js')->getURL()
     ]);
     $config->insertButtonsAfter('table', 'ssmedia');
     $config->insertButtonsAfter('ssmedia', 'ssembed');

--- a/_config.php
+++ b/_config.php
@@ -10,9 +10,12 @@ call_user_func(function () {
     // Re-enable media dialog
     $config = TinyMCEConfig::get('cms');
     $config->enablePlugins([
-        'ssmedia' => $module->getResource('client/dist/js/TinyMCE_ssmedia.js')->getURL(),
-        'ssembed' => $module->getResource('client/dist/js/TinyMCE_ssembed.js')->getURL(),
-        'sslinkfile' => $module->getResource('client/dist/js/TinyMCE_sslink-file.js')->getURL()
+        'ssmedia' => $module
+            ->getResource('client/dist/js/TinyMCE_ssmedia.js'),
+        'ssembed' => $module
+            ->getResource('client/dist/js/TinyMCE_ssembed.js'),
+        'sslinkfile' => $module
+            ->getResource('client/dist/js/TinyMCE_sslink-file.js'),
     ]);
     $config->insertButtonsAfter('table', 'ssmedia');
     $config->insertButtonsAfter('ssmedia', 'ssembed');

--- a/behat.yml
+++ b/behat.yml
@@ -2,7 +2,7 @@
 # Note that asset-admin behat tests require CMS module
 # ========================================================================= #
 # vendor/bin/selenium-server-standalone -Dwebdriver.firefox.bin="/Applications/Firefox31.app/Contents/MacOS/firefox-bin"
-# vendor/bin/serve --bootstrap-file cms/tests/behat/serve-bootstrap.php
+# vendor/bin/serve --bootstrap-file vendor/silverstripe/cms/tests/behat/serve-bootstrap.php
 # vendor/bin/behat @asset-admin
 # ========================================================================= #
 default:
@@ -25,7 +25,7 @@ default:
             - %paths.modules.asset-admin%/tests/behat/files/
   extensions:
     SilverStripe\BehatExtension\Extension:
-      bootstrap_file: cms/tests/behat/serve-bootstrap.php
+      bootstrap_file: vendor/silverstripe/cms/tests/behat/serve-bootstrap.php
       screenshot_path: %paths.base%/artifacts/screenshots
       retry_seconds: 4 # default is 2
     SilverStripe\BehatExtension\MinkExtension:

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,13 @@
 {
     "name": "silverstripe/asset-admin",
     "description": "Asset management for the SilverStripe CMS",
-    "type": "silverstripe-module",
+    "type": "silverstripe-vendormodule",
     "license": "BSD-3-Clause",
     "require": {
         "silverstripe/admin": "^1.0@dev",
         "silverstripe/framework": "^4@dev",
-        "silverstripe/graphql": "^0.2@dev"
+        "silverstripe/graphql": "^0.2@dev",
+        "silverstripe/vendor-plugin": "^1.0"
     },
     "require-dev": {
         "phpunit/PHPUnit": "^5.7",
@@ -20,7 +21,11 @@
         "branch-alias": {
             "1.x-dev": "1.0.x-dev",
             "dev-master": "2.x-dev"
-        }
+        },
+        "expose": [
+            "client/dist",
+            "client/lang"
+        ]
     },
     "scripts": {
         "lint": "phpcs -s code/ tests/"

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     ],
     "modulePaths": [
       "client/src",
-      "../silverstripe-admin/client/src",
-      "../silverstripe-admin/node_modules",
-      "silverstripe-admin/client/src",
-      "silverstripe-admin/node_modules"
+      "../admin/client/src",
+      "../admin/node_modules",
+      "vendor/silverstripe/admin/client/src",
+      "vendor/silverstripe/admin/node_modules"
     ],
     "testMatch": [
       "**/tests/**/*-test.js?(x)"
@@ -48,7 +48,7 @@
     }
   },
   "devDependencies": {
-    "@silverstripe/webpack-config": "^0.3.0",
+    "@silverstripe/webpack-config": "^0.4.0",
     "babel-jest": "^19.0.0",
     "jest-cli": "^19.0.2"
   },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,7 @@
 Standard module phpunit configuration.
 Requires PHPUnit ^5.7
 -->
-<phpunit bootstrap="framework/tests/bootstrap.php" colors="true">
+<phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
 	<testsuite name="Default">
 		<directory>tests/php</directory>
     </testsuite>

--- a/tests/php/Controller/AssetAdminTest.php
+++ b/tests/php/Controller/AssetAdminTest.php
@@ -217,7 +217,9 @@ class AssetAdminTest extends FunctionalTest
 
     public function testItRestrictsUpdateFile()
     {
+        /** @var File $allowedFile */
         $allowedFile = $this->objFromFixture(File::class, 'file1');
+        /** @var File $disallowedFile */
         $disallowedFile = $this->objFromFixture(File::class, 'disallowCanEdit');
 
         $response = Director::test(
@@ -228,6 +230,10 @@ class AssetAdminTest extends FunctionalTest
                 'Name' => 'disallowCanEdit.txt',
                 'Title' => 'new',
                 'SecurityID' => SecurityToken::inst()->getValue(),
+                'CanViewType' => $allowedFile->CanViewType,
+                'ViewerGroups' => 'unchanged',
+                'CanEditType' => $allowedFile->CanEditType,
+                'EditorGroups' => 'unchanged',
             ],
             $this->session
         );
@@ -240,6 +246,10 @@ class AssetAdminTest extends FunctionalTest
                 'ID' => $disallowedFile->ID,
                 'Title' => 'new',
                 'SecurityID' => SecurityToken::inst()->getValue(),
+                'CanViewType' => $disallowedFile->CanViewType,
+                'ViewerGroups' => 'unchanged',
+                'CanEditType' => $disallowedFile->CanEditType,
+                'EditorGroups' => 'unchanged',
             ],
             $this->session
         );
@@ -281,6 +291,10 @@ class AssetAdminTest extends FunctionalTest
                 'action_save' => 1,
                 'Name' => 'folder1-renamed',
                 'SecurityID' => SecurityToken::inst()->getValue(),
+                'CanViewType' => 'Inherit',
+                'ViewerGroups' => 'unchanged',
+                'CanEditType' => 'Inherit',
+                'EditorGroups' => 'unchanged',
             ]
         );
         $this->assertFalse($response->isError());

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@silverstripe/webpack-config@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@silverstripe/webpack-config/-/webpack-config-0.3.0.tgz#5d07c5fe128ecef3cf2b888b5660ed9cfd4c0da1"
+"@silverstripe/webpack-config@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@silverstripe/webpack-config/-/webpack-config-0.4.0.tgz#991041d839be43efb5903ba8de4771321cc67844"
   dependencies:
     autoprefixer "^6.4.0"
     babel-core "^6.24.1"


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-framework/issues/7405
Merge after https://github.com/silverstripe/silverstripe-framework/pull/7395

Manually tested creating folders and uploading/editing assets in asset-admin UI.

Test (after merging the framework pull request):

```
composer config repositories.asset-admin vcs https://github.com/open-sausages/silverstripe-asset-admin.git
composer require "silverstripe/asset-admin:dev-pulls/1/vendorise-me-baby as 1.0.x-dev"
```