### PR TITLE
ENHANCEMENT Add icon to add to campaign button

### DIFF
--- a/code/Extensions/CampaignAdminExtension.php
+++ b/code/Extensions/CampaignAdminExtension.php
@@ -22,10 +22,11 @@ class CampaignAdminExtension extends Extension
     public function updatePopoverActions(&$actions, $record)
     {
         if ($record && $record->canPublish()) {
-            array_unshift($actions, FormAction::create(
+            $action = FormAction::create(
                 'addtocampaign',
                 _t('SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.ADDTOCAMPAIGN', 'Add to campaign')
-            ));
+            )->setIcon('page-multiple');
+            array_unshift($actions, $action);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-admin/issues/274

Uses same icon as the campaigns section.

![image](https://user-images.githubusercontent.com/936064/32203106-02d0f698-be46-11e7-9a7f-cdc17c2476a4.png)

![image](https://user-images.githubusercontent.com/936064/32203110-0894cd5c-be46-11e7-82a5-2ae6e933fafb.png)
