### PR TITLE
Try using deprecated image to fix behat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: php
 
 dist: trusty
 
+sudo: required
+
+group: deprecated-2017Q4
+
 cache:
   directories:
     - $HOME/.composer/cache/files
@@ -37,7 +41,6 @@ matrix:
 
 before_script:
 # Init PHP
-  - printf "\n" | pecl install imagick
   - phpenv rehash
   - phpenv config-rm xdebug.ini
   - export PATH=~/.composer/vendor/bin:$PATH


### PR DESCRIPTION
This may fix behat:

current build log : https://api.travis-ci.org/v3/job/315697797/log.txt
working build log (from framework): https://api.travis-ci.org/v3/job/315160099/log.txt

I've discovered that the broken log is using a newer kernel version `Runtime kernel version: 4.9.6-040906-generic` instead of the working `Runtime kernel version: 4.4.0-93-generic`.

maybe using the deprecated image on travis will fix it.