### PR TITLE
Upgrade graphql to use callable connection types

### DIFF
--- a/code/GraphQL/FolderTypeCreator.php
+++ b/code/GraphQL/FolderTypeCreator.php
@@ -103,7 +103,9 @@ class FolderTypeCreator extends FileTypeCreator
     public function getChildrenConnection()
     {
         return Connection::create('Children')
-            ->setConnectionType($this->manager->getType('FileInterface'))
+            ->setConnectionType(function () {
+                return $this->manager->getType('FileInterface');
+            })
             ->setArgs(function () {
                 return [
                     'filter' => [

--- a/code/GraphQL/ReadFileQueryCreator.php
+++ b/code/GraphQL/ReadFileQueryCreator.php
@@ -24,22 +24,24 @@ class ReadFileQueryCreator extends PaginatedQueryCreator
     public function createConnection()
     {
         return Connection::create('readFiles')
-            ->setConnectionType(new UnionType([
-                'name' => 'Result',
-                'types' => [
-                    $this->manager->getType('File'),
-                    $this->manager->getType('Folder')
-                ],
-                'resolveType' => function ($object) {
-                    if ($object instanceof Folder) {
-                        return $this->manager->getType('Folder');
+            ->setConnectionType(function () {
+                return new UnionType([
+                    'name' => 'Result',
+                    'types' => [
+                        $this->manager->getType('File'),
+                        $this->manager->getType('Folder')
+                    ],
+                    'resolveType' => function ($object) {
+                        if ($object instanceof Folder) {
+                            return $this->manager->getType('Folder');
+                        }
+                        if ($object instanceof File) {
+                            return $this->manager->getType('File');
+                        }
+                        return null;
                     }
-                    if ($object instanceof File) {
-                        return $this->manager->getType('File');
-                    }
-                    return null;
-                }
-            ]))
+                ]);
+            })
             ->setArgs(function () {
                 return [
                     'filter' => [


### PR DESCRIPTION
Parent story https://github.com/silverstripe/silverstripe-graphql/issues/30

Using this callable format results in fewer register-order conditional errors.