### PR TITLE
Feature add a Usage tab showing owners of files

### DIFF
--- a/code/Forms/FileFormFactory.php
+++ b/code/Forms/FileFormFactory.php
@@ -3,17 +3,15 @@
 namespace SilverStripe\AssetAdmin\Forms;
 
 use SilverStripe\Admin\Forms\UsedOnTable;
-use SilverStripe\AssetAdmin\Controller\AssetAdmin;
 use SilverStripe\Assets\File;
 use SilverStripe\Control\RequestHandler;
 use SilverStripe\Forms\CheckboxField;
-use SilverStripe\Forms\FieldGroup;
 use SilverStripe\Forms\DatetimeField;
+use SilverStripe\Forms\FieldGroup;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\LiteralField;
-use SilverStripe\Forms\ReadonlyField;
 use SilverStripe\Forms\Tab;
 use SilverStripe\Forms\TabSet;
 use SilverStripe\Forms\TextField;
@@ -27,6 +25,11 @@ class FileFormFactory extends AssetFormFactory
      */
     private static $show_history = false;
 
+    /**
+     * @param File $record
+     * @param array $context
+     * @return TabSet
+     */
     protected function getFormFieldTabs($record, $context = [])
     {
         // Add extra tab
@@ -68,6 +71,11 @@ class FileFormFactory extends AssetFormFactory
         return $tabs;
     }
 
+    /**
+     * @param File $record
+     * @param array $context
+     * @return Tab
+     */
     protected function getFormFieldDetailsTab($record, $context = [])
     {
         // Update details tab
@@ -104,9 +112,14 @@ class FileFormFactory extends AssetFormFactory
         return $tab;
     }
 
+    /**
+     * @param File $record
+     * @param array $context
+     * @return Tab
+     */
     protected function getFormFieldUsageTab($record, $context = [])
     {
-        $usedOnField = UsedOnTable::create('UsedOnTable', $record);
+        $usedOnField = UsedOnTable::create('UsedOnTable');
 
         $tab = Tab::create(
             'Usage',
@@ -117,6 +130,11 @@ class FileFormFactory extends AssetFormFactory
         return $tab;
     }
 
+    /**
+     * @param File $record
+     * @param array $context
+     * @return Tab
+     */
     protected function getFormFieldLinkOptionsTab($record, $context = [])
     {
         $tab = Tab::create(
@@ -161,6 +179,11 @@ class FileFormFactory extends AssetFormFactory
         );
     }
 
+    /**
+     * @param File $record
+     * @param array $context
+     * @return Tab
+     */
     protected function getFormFieldHistoryTab($record, $context = [])
     {
         return Tab::create(
@@ -170,6 +193,14 @@ class FileFormFactory extends AssetFormFactory
         );
     }
 
+    /**
+     * Get fields for this form
+     *
+     * @param RequestHandler $controller
+     * @param string $formName
+     * @param array $context
+     * @return FieldList
+     */
     protected function getFormFields(RequestHandler $controller = null, $formName, $context = [])
     {
         /** @var File $record */
@@ -235,6 +266,12 @@ class FileFormFactory extends AssetFormFactory
         return $action;
     }
 
+    /**
+     * @param RequestHandler|null $controller
+     * @param string $formName
+     * @param array $context
+     * @return FieldList
+     */
     protected function getFormActions(RequestHandler $controller = null, $formName, $context = [])
     {
         $record = $context['Record'];
@@ -380,6 +417,9 @@ class FileFormFactory extends AssetFormFactory
         return $action;
     }
 
+    /**
+     * @return array
+     */
     public function getRequiredContext()
     {
         return parent::getRequiredContext() + [ 'RequireLinkText' ];

--- a/code/Forms/FileFormFactory.php
+++ b/code/Forms/FileFormFactory.php
@@ -2,6 +2,8 @@
 
 namespace SilverStripe\AssetAdmin\Forms;
 
+use SilverStripe\Admin\Forms\UsedOnTable;
+use SilverStripe\AssetAdmin\Controller\AssetAdmin;
 use SilverStripe\Assets\File;
 use SilverStripe\Control\RequestHandler;
 use SilverStripe\Forms\CheckboxField;
@@ -11,6 +13,7 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\LiteralField;
+use SilverStripe\Forms\ReadonlyField;
 use SilverStripe\Forms\Tab;
 use SilverStripe\Forms\TabSet;
 use SilverStripe\Forms\TextField;
@@ -30,7 +33,8 @@ class FileFormFactory extends AssetFormFactory
         $tabs = TabSet::create(
             'Editor',
             $this->getFormFieldDetailsTab($record, $context),
-            $this->getFormFieldSecurityTab($record, $context)
+            $this->getFormFieldSecurityTab($record, $context),
+            $this->getFormFieldUsageTab($record, $context)
         );
 
         if ($this->config()->get('show_history')) {
@@ -100,6 +104,19 @@ class FileFormFactory extends AssetFormFactory
         return $tab;
     }
 
+    protected function getFormFieldUsageTab($record, $context = [])
+    {
+        $usedOnField = UsedOnTable::create('UsedOnTable', $record);
+
+        $tab = Tab::create(
+            'Usage',
+            _t(__CLASS__.'.USAGE', 'Used on'),
+            $usedOnField
+        );
+
+        return $tab;
+    }
+
     protected function getFormFieldLinkOptionsTab($record, $context = [])
     {
         $tab = Tab::create(
@@ -162,7 +179,12 @@ class FileFormFactory extends AssetFormFactory
         $this->beforeExtending('updateFormFields', function (FieldList $fields) use ($record, $context) {
             if ($this->getFormType($context) === static::TYPE_INSERT_MEDIA) {
                 if ($record->appCategory() !== 'image') {
-                    $unembedableMsg = _t(__CLASS__.'.UNEMEDABLE_MESSAGE', '<p class="alert alert-info alert--no-border editor__top-message">This file type can only be inserted as a link. You can edit the link once it is inserted.</p>');
+                    $unembedableMsg = _t(
+                        __CLASS__.'.UNEMEDABLE_MESSAGE',
+                        '<p class="alert alert-info alert--no-border editor__top-message">'.
+                            'This file type can only be inserted as a link. You can edit the link once it is inserted.'.
+                        '</p>'
+                    );
                     $fields->unshift(LiteralField::create('UnembedableMessage', $unembedableMsg));
                 }
             }

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -77,6 +77,7 @@ en:
     INSERT_LINK: 'Link to file'
     LINKDESCR: 'Link description'
     LINKOPENNEWWIN: 'Open in new window/tab'
+    USAGE: 'Used on'
     LINKOPTIONS: 'Link options'
     LINKTEXT: 'Link text'
     OTHER_ACTIONS: 'Other actions'


### PR DESCRIPTION
This adds the new UsedOnTable FormField developed here https://github.com/silverstripe/silverstripe-admin/pull/427
A good idea to merge this after both https://github.com/silverstripe/silverstripe-cms/pull/2094 and https://github.com/silverstripe/silverstripe-admin/pull/427.

Please see https://github.com/silverstripe/silverstripe-asset-admin/issues/593 for more details