### PR TITLE
Add ability to use additional Toolbar buttons on the Gallery

### DIFF
--- a/client/src/containers/Gallery/Gallery.js
+++ b/client/src/containers/Gallery/Gallery.js
@@ -495,6 +495,19 @@ class Gallery extends Component {
     this.props.actions.gallery.setEnableDropzone(enabled);
   }
 
+  renderExtraToolbarButtons() {
+    if (window.assetAdmin && window.assetAdmin.gallery && window.assetAdmin.gallery.extraToolbarButtons) {
+      let extraButtons = window.assetAdmin.gallery.extraToolbarButtons;
+      return (
+        <div>
+          { extraButtons.map(ExtraButton => (
+            <ExtraButton />
+          ))}
+        </div>
+      );
+    }
+  }
+
   handleMoveFiles(folderId, fileIds) {
     this.props.actions.files.moveFiles(folderId, fileIds)
       .then(() => {
@@ -717,6 +730,7 @@ class Gallery extends Component {
       view,
       sort,
       folder,
+      children: this.renderExtraToolbarButtons()
     };
 
     return <GalleryToolbar {...props} />;


### PR DESCRIPTION
In a 3rd party JS file you can add a new Component that will be rendered

```js
import React, { Component, PropTypes } from 'react';

class NewButton extends Component {
    render() {
        return (
          <button
            className="btn btn-secondary font-icon-sync btn--icon-xl"
            type="button"
          >
            <span className="btn__text btn__title">Button Label<span>
          </button>
        )
    }
}

window.assetAdmin = window.assetAdmin || {};
window.assetAdmin.gallery = window.assetAdmin.gallery || {};
window.assetAdmin.gallery.extraToolbarButtons = window.assetAdmin.gallery.extraToolbarButtons || [];
window.assetAdmin.gallery.extraToolbarButtons.push(NewButton);
```