### PR TITLE
Update to use new recipe branching number

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_script:
 
 # Install composer
   - composer validate
-  - composer require silverstripe/recipe-testing:^1 silverstripe/recipe-cms 1.2.x-dev --no-update --prefer-dist
+  - composer require silverstripe/recipe-testing:^1 silverstripe/recipe-cms 4.2.x-dev --no-update --prefer-dist
   - composer update
 
 # Start behat services


### PR DESCRIPTION
Parent issue: https://github.com/silverstripe/recipe-core/issues/24

From 4.2 onwards all recipes will use the same numbering as the core framework version.