### PR TITLE
API Deprecate Embeddable and EmbedResource, shift into silverstripe/framework

### DIFF
--- a/_config/oembed.yml
+++ b/_config/oembed.yml
@@ -14,5 +14,6 @@ SilverStripe\AssetAdmin\Forms\RemoteFileFormFactory:
 Name: assetsoembed
 ---
 SilverStripe\Core\Injector\Injector:
+  # Backwards compatible configuration for loading Embeddable. Use Embeddable instead
   SilverStripe\AssetAdmin\Model\Embeddable:
-    class: SilverStripe\AssetAdmin\Model\EmbedResource
+    class: SilverStripe\View\Embed\Embeddable

--- a/code/Forms/RemoteFileFormFactory.php
+++ b/code/Forms/RemoteFileFormFactory.php
@@ -4,7 +4,6 @@ namespace SilverStripe\AssetAdmin\Forms;
 
 use Embed\Exceptions\InvalidUrlException;
 use InvalidArgumentException;
-use SilverStripe\AssetAdmin\Model\Embeddable;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\RequestHandler;
 use SilverStripe\Core\Config\Configurable;
@@ -21,6 +20,7 @@ use SilverStripe\Forms\LiteralField;
 use SilverStripe\Forms\OptionsetField;
 use SilverStripe\Forms\RequiredFields;
 use SilverStripe\Forms\TextField;
+use SilverStripe\View\Embed\Embeddable;
 
 class RemoteFileFormFactory implements FormFactory
 {

--- a/code/Model/EmbedResource.php
+++ b/code/Model/EmbedResource.php
@@ -2,78 +2,10 @@
 
 namespace SilverStripe\AssetAdmin\Model;
 
-use Embed\Adapters\Adapter;
-use Embed\Embed;
-use SilverStripe\Core\Manifest\ModuleResourceLoader;
-
 /**
- * Encapsulation of an embed tag, linking to an external media source.
- *
- * @see Embed
+ * @deprecated 1.2..2.0 Use {@link \SilverStripe\View\Embed\EmbedResource} instead
  */
-class EmbedResource implements Embeddable
+class EmbedResource extends \SilverStripe\View\Embed\EmbedResource
 {
-    /**
-     * Embed result
-     *
-     * @var Adapter
-     */
-    protected $embed;
 
-    public function __construct($url)
-    {
-        $this->embed = Embed::create($url);
-    }
-
-    public function getWidth()
-    {
-        return $this->embed->getWidth() ?: 100;
-    }
-
-    public function getHeight()
-    {
-        return $this->embed->getHeight() ?: 100;
-    }
-
-    public function getPreviewURL()
-    {
-        // Use thumbnail url
-        if ($this->embed->image) {
-            return $this->embed->image;
-        }
-
-        // Use direct image type
-        if ($this->getType() === 'photo' && !empty($this->embed->url)) {
-            return $this->embed->url;
-        }
-
-        // Default media
-        return ModuleResourceLoader::resourceURL(
-            'silverstripe/asset-admin:client/dist/images/icon_file.png'
-        );
-    }
-
-    /**
-     * Get human readable name for this resource
-     *
-     * @return string
-     */
-    public function getName()
-    {
-        if ($this->embed->title) {
-            return $this->embed->title;
-        }
-
-        return preg_replace('/\?.*/', '', basename($this->embed->getUrl()));
-    }
-
-    public function getType()
-    {
-        return $this->embed->type;
-    }
-
-    public function validate()
-    {
-        return !empty($this->embed->code);
-    }
 }

--- a/code/Model/Embeddable.php
+++ b/code/Model/Embeddable.php
@@ -3,51 +3,9 @@
 namespace SilverStripe\AssetAdmin\Model;
 
 /**
- * Abstract interface for an embeddable resource
- *
- * @see EmbedResource
+ * @deprecated 1.2..2.0 Use {@link Embeddable} instead
  */
-interface Embeddable
+interface Embeddable extends \SilverStripe\View\Embed\Embeddable
 {
-    /**
-     * Get width of this Embed
-     *
-     * @return int
-     */
-    public function getWidth();
 
-    /**
-     * Get height of this Embed
-     *
-     * @return int
-     */
-    public function getHeight();
-
-    /**
-     * Get preview url
-     *
-     * @return string
-     */
-    public function getPreviewURL();
-
-    /**
-     * Get human readable name for this resource
-     *
-     * @return string
-     */
-    public function getName();
-
-    /**
-     * Get Embed type
-     *
-     * @return string
-     */
-    public function getType();
-
-    /**
-     * Validate this resource
-     *
-     * @return bool
-     */
-    public function validate();
 }

--- a/tests/php/Forms/RemoteFileFormFactoryTest.php
+++ b/tests/php/Forms/RemoteFileFormFactoryTest.php
@@ -4,11 +4,11 @@ namespace SilverStripe\AssetAdmin\Tests\Forms;
 
 use Embed\Exceptions\InvalidUrlException;
 use SilverStripe\AssetAdmin\Forms\RemoteFileFormFactory;
-use SilverStripe\AssetAdmin\Model\Embeddable;
 use SilverStripe\AssetAdmin\Tests\Forms\RemoteFileFormFactoryTest\MockEmbed;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\Form;
+use SilverStripe\View\Embed\Embeddable;
 
 class RemoteFileFormFactoryTest extends SapphireTest
 {

--- a/tests/php/Forms/RemoteFileFormFactoryTest/MockEmbed.php
+++ b/tests/php/Forms/RemoteFileFormFactoryTest/MockEmbed.php
@@ -2,8 +2,8 @@
 
 namespace SilverStripe\AssetAdmin\Tests\Forms\RemoteFileFormFactoryTest;
 
-use SilverStripe\AssetAdmin\Model\Embeddable;
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\View\Embed\Embeddable;
 
 class MockEmbed implements Embeddable, TestOnly
 {


### PR DESCRIPTION
Framework has dependencies on these classes, so moving them into framework.

Requires https://github.com/silverstripe/silverstripe-framework/pull/8194

Issue: https://github.com/silverstripe/silverstripe-cms/issues/2168