### PR TITLE
FIX Use fixtured file title in test assertion

### DIFF
--- a/tests/php/Controller/AssetAdminTest.php
+++ b/tests/php/Controller/AssetAdminTest.php
@@ -327,7 +327,7 @@ class AssetAdminTest extends FunctionalTest
                 "title" => $file->Parent()->Title,
                 "filename" => $file->Parent()->Filename,
             ],
-            "title" => "The First File",
+            "title" => $file->Title,
             "exists" => $file->exists(),
             "category" => $file->appCategory(),
             "extension" => $file->Extension,


### PR DESCRIPTION
Fixes an odd global state issue that surfaces when running the recipe-cms testsuite in the CWP kitchen sink. Not reproducible in isolation. https://travis-ci.org/silverstripe/cwp-recipe-kitchen-sink/jobs/437571397#L1081

@dhensby suggested debugging the DB drivers to see if any rogue DDL commits are made, but TBH I don't have time to do that right now. It's super edge case and this patch fixes it the failing test.