### PR TITLE
NEW MoveFormFactory::getForm is now extensible and no longer uses divider lines

### DIFF
--- a/code/Forms/MoveFormFactory.php
+++ b/code/Forms/MoveFormFactory.php
@@ -4,6 +4,7 @@ namespace SilverStripe\AssetAdmin\Forms;
 
 use SilverStripe\Assets\Folder;
 use SilverStripe\Control\RequestHandler;
+use SilverStripe\Core\Extensible;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\FormAction;
@@ -12,6 +13,8 @@ use SilverStripe\Forms\TreeDropdownField;
 
 class MoveFormFactory implements FormFactory
 {
+    use Extensible;
+
     public function getForm(RequestHandler $controller = null, $name = self::DEFAULT_NAME, $context = [])
     {
         $form = Form::create(
@@ -30,6 +33,10 @@ class MoveFormFactory implements FormFactory
                     ->addExtraClass('btn-primary font-icon-folder-move')
             )
         );
+
+        $form->addExtraClass('form--no-dividers');
+
+        $this->extend('updateForm', $form, $controller, $name, $context);
 
         return $form;
     }


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/5170590/48345599-1b6b8100-e681-11e8-8414-ea64bff9fc3b.png)


After:

![image](https://user-images.githubusercontent.com/5170590/48345581-13abdc80-e681-11e8-99e7-d27320198dac.png)
