### PR TITLE
BUGFIX: Ensure list is limited appropriately before evaluating

### DIFF
--- a/code/GraphQL/FolderTypeCreator.php
+++ b/code/GraphQL/FolderTypeCreator.php
@@ -152,6 +152,8 @@ class FolderTypeCreator extends FileTypeCreator
 
         /** @var DataList $list */
         $list = Versioned::get_by_stage(File::class, 'Stage');
+        $result = $childrenConnection->resolveList($list, $args, $context, $info);
+        $list = $result['edges'];
         $filterInputType = new FileFilterInputTypeCreator($this->manager);
 
         $filter['parentId'] = $object->ID;


### PR DESCRIPTION
This prevents a potential memory leak when large numbers of assets are in the database. The `get_by_stage` call should be limited according to the parameters of the query.

## Notes
* This is not an ideal fix. The reliance on `$result['edges']` is due to the `resolveList()` function returning a data structure that is only suitable for GraphQL. There is a [separate PR for GraphQL](https://github.com/silverstripe/silverstripe-graphql/pull/191) that abstracts that out.  That PR is not a dependency of this fix

* ~Because the GraphQL PR is a new API, a separate PR will be made to asset-admin for the next minor release using the new GraphQL methods~ It's a pretty minor point, and probably not worth quibbling over.

