### PR TITLE
WIP Remove ImageBackendFactory Injector override from ImageThumbnailHelper

### DIFF
--- a/code/Helper/ImageThumbnailHelper.php
+++ b/code/Helper/ImageThumbnailHelper.php
@@ -15,11 +15,6 @@ class ImageThumbnailHelper
     public function run()
     {
         $assetAdmin = AssetAdmin::singleton();
-        $creator = new InjectionCreator();
-        Injector::inst()->registerService(
-            $creator,
-            ImageBackendFactory::class
-        );
         $files = File::get();
 
         set_time_limit(0);


### PR DESCRIPTION
`ImageThumbnailHelper` overrides `ImageBackendFactory` with `InjectionCreator`. This seems to increase the memory usage systematically when resizing big pictures. Not quite sure why, but I think some object hang around when `InjectionCreator`.

This doesn't actually show when calling `memory_get_peak_usage` because the memory is actually used by some process outside of PHP that's responsible for resizing the image.