### PR TITLE
NEW Remove ImageBackendFactory Injector override from ImageThumbnailHelper

### DIFF
--- a/code/Helper/ImageThumbnailHelper.php
+++ b/code/Helper/ImageThumbnailHelper.php
@@ -17,7 +17,8 @@ class ImageThumbnailHelper
     private $maxImageFileSize;
 
     /**
-     * @param mixed $maxImageSize Maximum file size for which thumbnails will be generated
+     * @param mixed $maxImageSize Maximum file size for which thumbnails will be generated. Set to `0` to disable the
+     * limit.
      */
     public function __construct($maxImageFileSize = '9M')
     {
@@ -25,6 +26,7 @@ class ImageThumbnailHelper
     }
 
     /**
+     * Get the maximum file size for which thumbnails will be generated. Set to `0` to disable the limit.
      * @return int
      */
     public function getMaxImageFileSize()
@@ -33,6 +35,7 @@ class ImageThumbnailHelper
     }
 
     /**
+     * Set the maximum file size for which thumbnails will be generated. Set to `0` to disable the limit.
      * @param mixed $size
      * @return $this
      */

--- a/code/Helper/ImageThumbnailHelper.php
+++ b/code/Helper/ImageThumbnailHelper.php
@@ -3,20 +3,58 @@ namespace SilverStripe\AssetAdmin\Helper;
 
 use SilverStripe\AssetAdmin\Controller\AssetAdmin;
 use SilverStripe\Assets\File;
+use SilverStripe\Core\Convert;
 use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\ORM\DB;
 
 class ImageThumbnailHelper
 {
     use Injectable;
 
+    /**
+     * @var int
+     */
+    private $maxImageFileSize;
+
+    /**
+     * @param mixed $maxImageSize Maximum file size for which thumbnails will be generated
+     */
+    public function __construct($maxImageFileSize = '9M')
+    {
+        $this->setMaxImageFileSize($maxImageFileSize);
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaxImageFileSize()
+    {
+        return $this->maxImageFileSize;
+    }
+
+    /**
+     * @param mixed $size
+     * @return $this
+     */
+    public function setMaxImageFileSize($size)
+    {
+        $this->maxImageFileSize = Convert::memstring2bytes($size);
+        return $this;
+    }
+
     public function run()
     {
         $assetAdmin = AssetAdmin::singleton();
+        /** @var File[] $files */
         $files = File::get();
 
         set_time_limit(0);
+
+        $maxSize = $this->getMaxImageFileSize();
         foreach ($files as $file) {
-            $assetAdmin->generateThumbnails($file, true);
+            if ($maxSize == 0 || $file->getAbsoluteSize() < $maxSize) {
+                $assetAdmin->generateThumbnails($file, true);
+            }
         }
     }
 }

--- a/code/Helper/ImageThumbnailHelper.php
+++ b/code/Helper/ImageThumbnailHelper.php
@@ -3,10 +3,7 @@ namespace SilverStripe\AssetAdmin\Helper;
 
 use SilverStripe\AssetAdmin\Controller\AssetAdmin;
 use SilverStripe\Assets\File;
-use SilverStripe\Assets\ImageBackendFactory;
 use SilverStripe\Core\Injector\Injectable;
-use SilverStripe\Core\Injector\InjectionCreator;
-use SilverStripe\Core\Injector\Injector;
 
 class ImageThumbnailHelper
 {
@@ -15,11 +12,6 @@ class ImageThumbnailHelper
     public function run()
     {
         $assetAdmin = AssetAdmin::singleton();
-        $creator = new InjectionCreator();
-        Injector::inst()->registerService(
-            $creator,
-            ImageBackendFactory::class
-        );
         $files = File::get();
 
         set_time_limit(0);


### PR DESCRIPTION
`ImageThumbnailHelper` overrides `ImageBackendFactory` with `InjectionCreator`. This seems to increase the memory usage systematically when resizing big pictures. Not quite sure why, but I think some object hang around when `InjectionCreator`.

This doesn't actually show when calling `memory_get_peak_usage` because the memory is actually used by some process outside of PHP that's responsible for resizing the image.

# Parent issue
* silverstripe/silverstripe-framework#8664