### PR TITLE
BUG Adjsut unit test to work with new natural paths

### DIFF
--- a/tests/php/GraphQL/FileTypeCreatorTest.php
+++ b/tests/php/GraphQL/FileTypeCreatorTest.php
@@ -60,7 +60,7 @@ class FileTypeCreatorTest extends SapphireTest
         // public image should have url
         $image->publishSingle();
         $thumbnail = $type->resolveThumbnailField($image, [], [], null);
-        $this->assertEquals('/assets/FileTypeCreatorTest/8cf6c65fa7/TestImage__FitMaxWzM1MiwyNjRd.png', $thumbnail);
+        $this->assertEquals('/assets/FileTypeCreatorTest/TestImage__FitMaxWzM1MiwyNjRd.png', $thumbnail);
 
         // Public assets can be set to inline
         ThumbnailGenerator::config()->merge('thumbnail_links', [

--- a/tests/php/Model/ThumbnailGeneratorTest.php
+++ b/tests/php/Model/ThumbnailGeneratorTest.php
@@ -86,7 +86,7 @@ class ThumbnailGeneratorTest extends SapphireTest
         // public image should have url
         $image->publishSingle();
         $thumbnail = $generator->generateThumbnailLink($image, 100, 200);
-        $this->assertEquals('/assets/ThumbnailGeneratorTest/906835357d/TestImage__FitMaxWzEwMCwyMDBd.png', $thumbnail);
+        $this->assertEquals('/assets/ThumbnailGeneratorTest/TestImage__FitMaxWzEwMCwyMDBd.png', $thumbnail);
 
         // Public assets can be set to inline
         ThumbnailGenerator::config()->merge('thumbnail_links', [


### PR DESCRIPTION
Minor unit test fix to work with new natural path for public files

# Parent issue
* https://github.com/silverstripe/silverstripe-versioned/issues/177

# Depends on
* https://github.com/silverstripe/silverstripe-assets/pull/223