### PR TITLE
FIX folders always go first when ordering

### DIFF
--- a/code/GraphQL/FolderTypeCreator.php
+++ b/code/GraphQL/FolderTypeCreator.php
@@ -166,21 +166,16 @@ class FolderTypeCreator extends FileTypeCreator
                 $existingOrderBys = [];
                 foreach ($query->getOrderBy() as $field => $direction) {
                     if (strpos($field, '.') === false) {
-                        // some fields may be surrogates added by extending augmentSQL (e.g. fluent)
+                        // some fields may be surrogates added by extending augmentSQL
                         // we have to preserve those expressions rather than auto-generated names
-                        // that SQLSelect::addOrderBy leaves for them (usually that's alike _SortColumn0)
-                        //
-                        // see related issues for more details:
-                        //  - https://github.com/silverstripe/silverstripe-asset-admin/issues/820
-                        //  - https://github.com/silverstripe/silverstripe-asset-admin/issues/893
+                        // that SQLSelect::addOrderBy leaves for them (e.g. _SortColumn0)
                         $field = $query->expressionForField(trim($field, '"')) ?: $field;
                     }
 
                     $existingOrderBys[$field] = $direction;
                 }
 
-                // Folders should always go first due to backwards compatibility
-                // See https://github.com/silverstripe/silverstripe-asset-admin/issues/893
+                // Folders should always go first
                 $dataQuery->sort(
                     sprintf(
                         '(CASE WHEN "ClassName"=%s THEN 1 ELSE 0 END)',

--- a/tests/php/GraphQL/FolderTypeCreatorTest.php
+++ b/tests/php/GraphQL/FolderTypeCreatorTest.php
@@ -18,6 +18,26 @@ class FolderTypeCreatorTest extends SapphireTest
 
     protected $usesDatabase = true;
 
+    public function testItSortsChildrenOnTypeByDefault()
+    {
+        $rootFolder = Folder::singleton();
+        $file = File::create(['Name' => 'aaa file']);
+        $file->write();
+        $folder = Folder::create(['Name' => 'bbb folder']);
+        $folder->write();
+        $list = $this->resolveChildrenConnection(
+            $rootFolder,
+            []
+        );
+        $this->assertEquals(
+            [
+                $folder->Name,
+                $file->Name,
+            ],
+            $list['edges']->column('Name')
+        );
+    }
+
     public function testItDoesNotFilterByParentIdWithRecursiveFlag()
     {
         $rootFolder = Folder::singleton();


### PR DESCRIPTION
Fix for https://github.com/silverstripe/silverstripe-asset-admin/issues/893
Also fixes the original fluent issue (https://github.com/silverstripe/silverstripe-asset-admin/issues/820)

## Notes
 - tested on silverstripe/installer 4.x-dev
 - tested on silverstripe/installer 4.2.x-dev
 - tested on cwp/cwp-recipe-kitchen-sink ^2