### PR TITLE
Better formatting of file migration tasks

### DIFF
--- a/code/Helper/ImageThumbnailHelper.php
+++ b/code/Helper/ImageThumbnailHelper.php
@@ -3,9 +3,12 @@ namespace SilverStripe\AssetAdmin\Helper;
 
 use Psr\Log\LoggerInterface;
 use SilverStripe\AssetAdmin\Controller\AssetAdmin;
+use SilverStripe\AssetAdmin\Forms\UploadField;
 use SilverStripe\Assets\File;
+use SilverStripe\Assets\Storage\AssetStore;
 use SilverStripe\Core\Convert;
 use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\DB;
 use SilverStripe\ORM\SS_List;
 
@@ -26,6 +29,8 @@ class ImageThumbnailHelper
      * @var int
      */
     private $maxImageFileSize;
+
+    private $processedBatchSize = 100;
 
     /**
      * @param LoggerInterface $logger
@@ -67,9 +72,11 @@ class ImageThumbnailHelper
         return $this;
     }
 
+    /**
+     * @return int Number of thumbnails processed
+     */
     public function run()
     {
-        $assetAdmin = AssetAdmin::singleton();
         /** @var File[]|SS_List $files */
         $files = File::get();
         $totalCount = $files->count();
@@ -77,25 +84,83 @@ class ImageThumbnailHelper
             return 0;
         }
 
-        $this->logger->info(sprintf('Generating %d thumbnails', $totalCount));
+        $this->logger->debug(sprintf('Inspecting %d files', $totalCount));
 
         set_time_limit(0);
 
         $maxSize = $this->getMaxImageFileSize();
-        $processedCount = 0;
+        $inspectedCount = 0;
+        $generatedCount = 0;
         foreach ($files as $file) {
-            $this->logger->info(sprintf('Generating thumbnail for %s', $file->Filename));
-            if ($maxSize == 0 || $file->getAbsoluteSize() < $maxSize) {
-                $assetAdmin->generateThumbnails($file, true);
+            // Skip if file is too large
+            if ($maxSize > 0 && $file->getAbsoluteSize() > $maxSize) {
+                continue;
             }
 
-            $processedCount++;
-            $this->logger->info(sprintf(
-                '[%d / %d, %d%% complete]',
-                $processedCount,
-                $totalCount,
-                floor(($processedCount / $totalCount) * 100)
-            ));
+            $generated = $this->generateThumbnails($file);
+            if (count($generated) > 0) {
+                $generatedCount++;
+                $this->logger->debug(sprintf('Generated thumbnail for %s', $file->Filename));
+            }
+
+            $inspectedCount++;
+
+            if ($inspectedCount % $this->processedBatchSize == 0) {
+                $this->logger->debug(sprintf(
+                    '[%d / %d, %d%% complete]',
+                    $inspectedCount,
+                    $totalCount,
+                    floor(($inspectedCount / $totalCount) * 100)
+                ));
+            }
         }
+
+        return $generatedCount;
+    }
+
+    /**
+     * Similar to AssetAdmin->generateThumbnails(),
+     * but with the ability to tell if a file actually required to be generated.
+     * This speeds up the process, and removes some noise when thumbnails
+     * have already been generated.
+     *
+     * @param File $file
+     * @return AssetContainer[] All generated files
+     */
+    protected function generateThumbnails(File $file)
+    {
+        $generated = [];
+
+        $store = Injector::inst()->get(AssetStore::class);
+        $assetAdmin = AssetAdmin::singleton();
+        $generator = $assetAdmin->getThumbnailGenerator();
+        $method = $generator->config()->get('method');
+
+        $dimensions = [
+            [
+                UploadField::config()->uninherited('thumbnail_width'),
+                UploadField::config()->uninherited('thumbnail_height')
+            ],
+            [
+                $assetAdmin->config()->get('thumbnail_width'),
+                $assetAdmin->config()->get('thumbnail_height')
+            ]
+        ];
+
+        foreach ($dimensions as $dimension) {
+            $variant = $file->variantName($method, $dimension[0], $dimension[1]);
+            if ($store->exists($file->getFilename(), $file->getHash(), $variant)) {
+                continue;
+            }
+
+            $thumb = $generator->generateThumbnail($file, $dimension[0], $dimension[1]);
+
+            // Not all file formats support thumbnail generation
+            if ($thumb) {
+                $generated[] = $thumb;
+            }
+        }
+
+        return $generated;
     }
 }

--- a/code/Helper/ImageThumbnailHelper.php
+++ b/code/Helper/ImageThumbnailHelper.php
@@ -94,6 +94,10 @@ class ImageThumbnailHelper
         foreach ($files as $file) {
             // Skip if file is too large
             if ($maxSize > 0 && $file->getAbsoluteSize() > $maxSize) {
+                $this->logger->warning(sprintf(
+                    'File too large for thumbnail for generating thumbnail: %s',
+                    $file->Filename
+                ));
                 continue;
             }
 

--- a/code/Model/ThumbnailGenerator.php
+++ b/code/Model/ThumbnailGenerator.php
@@ -60,6 +60,12 @@ class ThumbnailGenerator
     ];
 
     /**
+     * @var string
+     * @config
+     */
+    private static $method = 'FitMax';
+
+    /**
      * Generate thumbnail and return the "src" property for this thumbnail
      *
      * @param AssetContainer|DBFile|File $file
@@ -94,9 +100,10 @@ class ThumbnailGenerator
         }
 
         // Make large thumbnail
-        return $file->FitMax($width, $height);
+        $method = $this->config()->get('method');
+        return $file->$method($width, $height);
     }
-
+    
     /**
      * Generate "src" property for this thumbnail.
      * This can be either a url or base64 encoded data


### PR DESCRIPTION
Don't pretend to generate thumbnails when you're not.
Ideally we could use AssetAdmin->generateThumbnails() for this,
but there's no way to distinguish the "generated" vs. "existing" case
without dropping deep down into ImageManipulation->manipulate().

Since this is a dev task for one off migrations, I think this duplication
is feasible. It means that in the unlikely case where we significantly change the types
of thumbnails generated in AssetAdmin, we might need to adjust this migration task as well.

See https://github.com/silverstripe/silverstripe-framework/issues/8962