### PR TITLE
ENHANCEMENT: Large thumbnails fallback on URL

### DIFF
--- a/code/GraphQL/FileTypeCreator.php
+++ b/code/GraphQL/FileTypeCreator.php
@@ -9,6 +9,8 @@ use SilverStripe\AssetAdmin\Forms\UploadField;
 use SilverStripe\AssetAdmin\Model\ThumbnailGenerator;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Folder;
+use SilverStripe\Assets\Storage\AssetContainer;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\GraphQL\Manager;
 use SilverStripe\GraphQL\TypeCreator;
 use SilverStripe\GraphQL\Util\CaseInsensitiveFieldAccessor;
@@ -100,9 +102,11 @@ class FileTypeCreator extends TypeCreator
             ],
             'thumbnail' => [
                 'type' => Type::string(),
+                'resolve' => [static::class, 'resolveThumbnailFieldGraceful'],
             ],
             'smallThumbnail' => [
                 'type' => Type::string(),
+                'resolve' => [static::class, 'resolveSmallThumbnailFieldGraceful'],
             ],
             'width' => [
                 'type' => Type::int(),
@@ -261,4 +265,43 @@ class FileTypeCreator extends TypeCreator
         $this->thumbnailGenerator = $generator;
         return $this;
     }
+
+    /**
+     * @param AssetContainer $object
+     * @param $args
+     * @param $context
+     * @param $info
+     * @return string
+     * @deprecated 2.0
+     */
+    public static function resolveThumbnailFieldGraceful(AssetContainer $object, $args, $context, $info): string
+    {
+        Deprecation::notice('2.0', 'Use resolveThumbnailField');
+        $width = AssetAdmin::config()->uninherited('thumbnail_width');
+        $height = AssetAdmin::config()->uninherited('thumbnail_height');
+        return static::singleton()
+            ->getThumbnailGenerator()
+            ->generateThumbnailLink($object, $width, $height, true);
+
+    }
+
+    /**
+     * @param AssetContainer $object
+     * @param $args
+     * @param $context
+     * @param $info
+     * @return string
+     * @deprecated 2.0
+     */
+    public static function resolveSmallThumbnailFieldGraceful(AssetContainer $object, $args, $context, $info): string
+    {
+        Deprecation::notice('2.0', 'Use resolveSmallThumbnailField');
+        $width = UploadField::config()->uninherited('thumbnail_width');
+        $height = UploadField::config()->uninherited('thumbnail_height');
+        return static::singleton()
+            ->getThumbnailGenerator()
+            ->generateThumbnailLink($object, $width, $height, true);
+
+    }
+
 }

--- a/code/GraphQL/FileTypeCreator.php
+++ b/code/GraphQL/FileTypeCreator.php
@@ -268,13 +268,13 @@ class FileTypeCreator extends TypeCreator
 
     /**
      * @param AssetContainer $object
-     * @param $args
-     * @param $context
-     * @param $info
-     * @return string
-     * @deprecated 2.0
+     * @param array $args
+     * @param array $context
+     * @param ResolveInfo $info
+     * @return string|null
+     * @deprecated 2.0:2.1
      */
-    public static function resolveThumbnailFieldGraceful(AssetContainer $object, $args, $context, $info): string
+    public static function resolveThumbnailFieldGraceful(AssetContainer $object, $args, $context, $info): ?string
     {
         Deprecation::notice('2.0', 'Use resolveThumbnailField');
         $width = AssetAdmin::config()->uninherited('thumbnail_width');
@@ -287,13 +287,13 @@ class FileTypeCreator extends TypeCreator
 
     /**
      * @param AssetContainer $object
-     * @param $args
-     * @param $context
-     * @param $info
-     * @return string
-     * @deprecated 2.0
+     * @param array $args
+     * @param array $context
+     * @param ResolveInfo $info
+     * @return string|null
+     * @deprecated 2.0:2.1
      */
-    public static function resolveSmallThumbnailFieldGraceful(AssetContainer $object, $args, $context, $info): string
+    public static function resolveSmallThumbnailFieldGraceful(AssetContainer $object, $args, $context, $info): ?string
     {
         Deprecation::notice('2.0', 'Use resolveSmallThumbnailField');
         $width = UploadField::config()->uninherited('thumbnail_width');

--- a/code/GraphQL/FileTypeCreator.php
+++ b/code/GraphQL/FileTypeCreator.php
@@ -280,7 +280,6 @@ class FileTypeCreator extends TypeCreator
         return static::singleton()
             ->getThumbnailGenerator()
             ->generateThumbnailLink($object, $width, $height, true);
-
     }
 
     /**
@@ -297,7 +296,5 @@ class FileTypeCreator extends TypeCreator
         return static::singleton()
             ->getThumbnailGenerator()
             ->generateThumbnailLink($object, $width, $height, true);
-
     }
-
 }

--- a/code/GraphQL/FileTypeCreator.php
+++ b/code/GraphQL/FileTypeCreator.php
@@ -272,11 +272,9 @@ class FileTypeCreator extends TypeCreator
      * @param array $context
      * @param ResolveInfo $info
      * @return string|null
-     * @deprecated 2.0:2.1
      */
     public static function resolveThumbnailFieldGraceful(AssetContainer $object, $args, $context, $info): ?string
     {
-        Deprecation::notice('2.0', 'Use resolveThumbnailField');
         $width = AssetAdmin::config()->uninherited('thumbnail_width');
         $height = AssetAdmin::config()->uninherited('thumbnail_height');
         return static::singleton()
@@ -291,11 +289,9 @@ class FileTypeCreator extends TypeCreator
      * @param array $context
      * @param ResolveInfo $info
      * @return string|null
-     * @deprecated 2.0:2.1
      */
     public static function resolveSmallThumbnailFieldGraceful(AssetContainer $object, $args, $context, $info): ?string
     {
-        Deprecation::notice('2.0', 'Use resolveSmallThumbnailField');
         $width = UploadField::config()->uninherited('thumbnail_width');
         $height = UploadField::config()->uninherited('thumbnail_height');
         return static::singleton()

--- a/code/Model/ThumbnailGenerator.php
+++ b/code/Model/ThumbnailGenerator.php
@@ -77,7 +77,9 @@ class ThumbnailGenerator
     public function generateThumbnailLink(AssetContainer $file, $width, $height, $graceful = false)
     {
         $thumbnail = $this->generateThumbnail($file, $width, $height);
-
+        if (!$thumbnail) {
+            return null;
+        }
         $result = $this->generateLink($thumbnail);
         if ($graceful && $result === null && $thumbnail->exists() && $thumbnail->getIsImage()) {
             return $thumbnail->getURL();

--- a/code/Model/ThumbnailGenerator.php
+++ b/code/Model/ThumbnailGenerator.php
@@ -72,7 +72,7 @@ class ThumbnailGenerator
      * @param int $width
      * @param int $height
      * @param bool $graceful If true, null result will fallback on URL
-     * @return string
+     * @return string|null
      */
     public function generateThumbnailLink(AssetContainer $file, $width, $height, $graceful = false)
     {

--- a/code/Model/ThumbnailGenerator.php
+++ b/code/Model/ThumbnailGenerator.php
@@ -71,13 +71,19 @@ class ThumbnailGenerator
      * @param AssetContainer|DBFile|File $file
      * @param int $width
      * @param int $height
+     * @param bool $graceful If true, null result will fallback on URL
      * @return string
      */
-    public function generateThumbnailLink(AssetContainer $file, $width, $height)
+    public function generateThumbnailLink(AssetContainer $file, $width, $height, $graceful = false)
     {
         $thumbnail = $this->generateThumbnail($file, $width, $height);
 
-        return $this->generateLink($thumbnail);
+        $result = $this->generateLink($thumbnail);
+        if ($graceful && $result === null && $thumbnail->exists() && $thumbnail->getIsImage()) {
+            return $thumbnail->getURL();
+        }
+
+        return $result;
     }
 
     /**
@@ -117,10 +123,9 @@ class ThumbnailGenerator
         if (!$thumbnail || !$thumbnail->exists() || !$thumbnail->getIsImage()) {
             return null;
         }
-
         // Ensure thumbnail doesn't exceed safe bounds
         $maxSize = $this->config()->get('max_thumbnail_bytes');
-        if (!$thumbnail->getAbsoluteSize() > $maxSize) {
+        if ($thumbnail->getAbsoluteSize() > $maxSize) {
             return null;
         }
 

--- a/tests/php/Model/ThumbnailGeneratorTest.php
+++ b/tests/php/Model/ThumbnailGeneratorTest.php
@@ -7,6 +7,7 @@ use SilverStripe\Assets\File;
 use SilverStripe\Assets\Image;
 use SilverStripe\Assets\Storage\AssetStore;
 use Silverstripe\Assets\Dev\TestAssetStore;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
 
 class ThumbnailGeneratorTest extends SapphireTest
@@ -82,6 +83,17 @@ class ThumbnailGeneratorTest extends SapphireTest
         // protected image should have inline thumbnail
         $thumbnail = $generator->generateThumbnailLink($image, 100, 200);
         $this->assertStringStartsWith('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAAAy', $thumbnail);
+
+        // but not if it's too big
+        Config::nest();
+        Config::modify()->set(ThumbnailGenerator::class, 'max_thumbnail_bytes', 1);
+        // Without graceful thumbnails, it should come back null
+        $thumbnail = $generator->generateThumbnailLink($image, 100, 200);
+        $this->assertNull($thumbnail);
+        // With graceful thumbnails, it should come back as a URL
+        $thumbnail = $generator->generateThumbnailLink($image, 100, 200, true);
+        $this->assertEquals('/assets/ThumbnailGeneratorTest/TestImage__FitMaxWzEwMCwyMDBd.png', $thumbnail);
+        Config::unnest();
 
         // public image should have url
         $image->publishSingle();

--- a/tests/php/Model/ThumbnailGeneratorTest.php
+++ b/tests/php/Model/ThumbnailGeneratorTest.php
@@ -92,7 +92,7 @@ class ThumbnailGeneratorTest extends SapphireTest
         $this->assertNull($thumbnail);
         // With graceful thumbnails, it should come back as a URL
         $thumbnail = $generator->generateThumbnailLink($image, 100, 200, true);
-        $this->assertEquals('/assets/ThumbnailGeneratorTest/TestImage__FitMaxWzEwMCwyMDBd.png', $thumbnail);
+        $this->assertRegExp('#/assets/[A-Za-z0-9]+/TestImage__FitMaxWzEwMCwyMDBd\.png$#', $thumbnail);
         Config::unnest();
 
         // public image should have url


### PR DESCRIPTION
Resolves: https://github.com/silverstripe/silverstripe-asset-admin/issues/930


This PR is quite verbose, in the interest of preserving public APIs.

* New field resolvers for thumbnails (static, to be compatible with future GraphQL release with schema caching)
* `generateThumbnailLink()` now takes a `$graceful` parameter, backward compatible, which allows the thumbnail result to fallback on URL if too large

Separate PR for the master branch (2.0) will simply change the return value of the `generateThumbnailLink()` method. 