### PR TITLE
FIX Optimise AssetAdminFile::nestedFolderIDs

### DIFF
--- a/code/Controller/AssetAdminFile.php
+++ b/code/Controller/AssetAdminFile.php
@@ -206,20 +206,22 @@ class AssetAdminFile extends DataExtension
     /**
      * Get recursive parent IDs
      *
-     * @param int $parentID
+     * @param int|int[] $parentIDorIDs
      * @param int $maxDepth Hard limit of max depth
      * @return array List of parent IDs, including $parentID
      */
-    public static function nestedFolderIDs($parentID, $maxDepth = 5)
+    public static function nestedFolderIDs($parentIDorIDs, $maxDepth = 5)
     {
-        $ids = [$parentID];
+        $ids = is_array($parentIDorIDs) ? $parentIDorIDs : [$parentIDorIDs];
         if ($maxDepth === 0) {
             return $ids;
         }
-        $childIDs = Folder::get()->filter('ParentID', $parentID)->column('ID');
-        foreach ($childIDs as $childID) {
-            $ids = array_merge($ids, static::nestedFolderIDs($childID, $maxDepth - 1));
+        $childIDs = Folder::get()->filter('ParentID', $parentIDorIDs)->column('ID');
+
+        if (empty($childIDs)) {
+            return $ids;
         }
-        return $ids;
+
+        return array_merge($ids, static::nestedFolderIDs($childIDs, $maxDepth - 1));
     }
 }

--- a/tests/php/Controller/AssetAdminFileTest.php
+++ b/tests/php/Controller/AssetAdminFileTest.php
@@ -20,13 +20,13 @@ class AssetAdminFileTest extends SapphireTest
         $this->assertCount(8, $names); // 7 children but the original ID is included
         $this->assertCount(8, array_intersect([
             'folder1',
-            'folder1.1',
-            'folder1.2',
-            'folder1.1.1',
-            'folder1.2.1',
-            'folder1.2.2',
-            'folder1.1.1.1',
-            'folder1.2.2.1',
-        ], $names));
+            'folder1-1',
+            'folder1-2',
+            'folder1-1-1',
+            'folder1-2-1',
+            'folder1-2-2',
+            'folder1-1-1-1',
+            'folder1-2-2-1',
+        ], $names), 'Names match those saved to the database (' . implode(', ', $names) . ')');
     }
 }

--- a/tests/php/Controller/AssetAdminFileTest.php
+++ b/tests/php/Controller/AssetAdminFileTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace SilverStripe\AssetAdmin\Tests\Controller;
+
+use SilverStripe\AssetAdmin\Controller\AssetAdminFile;
+use SilverStripe\Assets\Folder;
+use SilverStripe\Dev\SapphireTest;
+
+class AssetAdminFileTest extends SapphireTest
+{
+    protected static $fixture_file = 'AssetAdminFileTest.yml';
+
+    public function testNestedFolderIds()
+    {
+        $parent = $this->objFromFixture(Folder::class, 'folder1');
+
+        $ids = AssetAdminFile::nestedFolderIDs($parent->ID);
+
+        $names = Folder::get()->byIDs($ids)->column('Title');
+        $this->assertCount(8, $names); // 7 children but the original ID is included
+        $this->assertCount(8, array_intersect([
+            'folder1',
+            'folder1.1',
+            'folder1.2',
+            'folder1.1.1',
+            'folder1.2.1',
+            'folder1.2.2',
+            'folder1.1.1.1',
+            'folder1.2.2.1',
+        ], $names));
+    }
+}

--- a/tests/php/Controller/AssetAdminFileTest.yml
+++ b/tests/php/Controller/AssetAdminFileTest.yml
@@ -3,24 +3,24 @@ SilverStripe\Assets\Folder:
     Title: folder1
   folder2:
     Title: folder2
-  folder1.1:
-    Title: folder1.1
+  folder11:
+    Title: folder1-1
     Parent: =>SilverStripe\Assets\Folder.folder1
-  folder1.2:
-    Title: folder1.2
+  folder12:
+    Title: folder1-2
     Parent: =>SilverStripe\Assets\Folder.folder1
-  folder1.1.1:
-    Title: folder1.1.1
-    Parent: =>SilverStripe\Assets\Folder.folder1.1
-  folder1.2.1:
-    Title: folder1.2.1
-    Parent: =>SilverStripe\Assets\Folder.folder1.2
-  folder1.2.2:
-    Title: folder1.2.2
-    Parent: =>SilverStripe\Assets\Folder.folder1.2
-  folder1.1.1.1:
-    Title: folder1.1.1.1
-    Parent: =>SilverStripe\Assets\Folder.folder1.1.1
-  folder1.2.2.1:
-    Title: folder1.2.2.1
-    Parent: =>SilverStripe\Assets\Folder.folder1.2.2
+  folder111:
+    Title: folder1-1-1
+    Parent: =>SilverStripe\Assets\Folder.folder11
+  folder121:
+    Title: folder1-2-1
+    Parent: =>SilverStripe\Assets\Folder.folder12
+  folder122:
+    Title: folder1-2-2
+    Parent: =>SilverStripe\Assets\Folder.folder12
+  folder1111:
+    Title: folder1-1-1-1
+    Parent: =>SilverStripe\Assets\Folder.folder111
+  folder1221:
+    Title: folder1-2-2-1
+    Parent: =>SilverStripe\Assets\Folder.folder122

--- a/tests/php/Controller/AssetAdminFileTest.yml
+++ b/tests/php/Controller/AssetAdminFileTest.yml
@@ -1,0 +1,26 @@
+SilverStripe\Assets\Folder:
+  folder1:
+    Title: folder1
+  folder2:
+    Title: folder2
+  folder1.1:
+    Title: folder1.1
+    Parent: =>SilverStripe\Assets\Folder.folder1
+  folder1.2:
+    Title: folder1.2
+    Parent: =>SilverStripe\Assets\Folder.folder1
+  folder1.1.1:
+    Title: folder1.1.1
+    Parent: =>SilverStripe\Assets\Folder.folder1.1
+  folder1.2.1:
+    Title: folder1.2.1
+    Parent: =>SilverStripe\Assets\Folder.folder1.2
+  folder1.2.2:
+    Title: folder1.2.2
+    Parent: =>SilverStripe\Assets\Folder.folder1.2
+  folder1.1.1.1:
+    Title: folder1.1.1.1
+    Parent: =>SilverStripe\Assets\Folder.folder1.1.1
+  folder1.2.2.1:
+    Title: folder1.2.2.1
+    Parent: =>SilverStripe\Assets\Folder.folder1.2.2


### PR DESCRIPTION
Attempts to solve #931

Previously the code would fetch children for each folder. Given a structure like this:

```
1
⎿ 1.1
   ⎿ 1.1.1
      ⎿ 1.1.1.1
⎿ 1.2
   ⎿ 1.2.1
   ⎿ 1.2.2
⎿ 1.3
   ⎿ 1.3.1
⎿ 1.4
⎿ 1.5
   ⎿ 1.5.1
```

A query would run to find children of each folder (12 queries). This change means it now fetches folders by "level". So it would be reduced to 4 queries for the above structure.
   
