### PR TITLE
Allow thumbnail generator to skip non-image files before file size check

### DIFF
--- a/code/Helper/ImageThumbnailHelper.php
+++ b/code/Helper/ImageThumbnailHelper.php
@@ -92,10 +92,15 @@ class ImageThumbnailHelper
         $inspectedCount = 0;
         $generatedCount = 0;
         foreach ($files as $file) {
+            // Skip if file is not an image
+            if (!$file->getIsImage()) {
+                $this->logger->debug(sprintf('File is not an image: %s', $file->Filename));
+                continue;
+            }
             // Skip if file is too large
             if ($maxSize > 0 && $file->getAbsoluteSize() > $maxSize) {
                 $this->logger->warning(sprintf(
-                    'File too large for thumbnail for generating thumbnail: %s',
+                    'File too large for generating its thumbnail: %s',
                     $file->Filename
                 ));
                 continue;


### PR DESCRIPTION
Even though `$generated = $this->generateThumbnails($file);` checks for the file being an image, some files (like large PDFs and/or videos) produce warnings being too large before arriving at that point, unnecessarily polluting the migration log.

This checks for the file type being an image early in the loop.