### PR TITLE
BUG Honour AssetAdminFile insert dimentions when inserting a new image

### DIFF
--- a/code/Forms/ImageFormFactory.php
+++ b/code/Forms/ImageFormFactory.php
@@ -141,9 +141,9 @@ class ImageFormFactory extends FileFormFactory
     }
 
     /**
-     * Retrieve the approprite insert dimension for the image, if available.
+     * Retrieve the appropriate insert dimension for the image, if available.
      * @param Image $context
-     * @return array|false
+     * @return array|null
      */
     private function getInsertDimensions($context)
     {
@@ -156,6 +156,6 @@ class ImageFormFactory extends FileFormFactory
                 'Height' => $context->getInsertHeight(),
             ];
         }
-        return false;
+        return null;
     }
 }

--- a/code/Forms/ImageFormFactory.php
+++ b/code/Forms/ImageFormFactory.php
@@ -8,6 +8,7 @@ use SilverStripe\Forms\FieldGroup;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\FormFactory;
+use SilverStripe\Forms\NumericField;
 use SilverStripe\Forms\OptionsetField;
 use SilverStripe\Forms\Tab;
 use SilverStripe\Forms\TextField;
@@ -55,13 +56,13 @@ class ImageFormFactory extends FileFormFactory
         $tab->push(
             FieldGroup::create(
                 _t('SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.ImageSpecs', 'Dimensions'),
-                TextField::create(
+                NumericField::create(
                     'Width',
                     _t('SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.ImageWidth', 'Width')
                 )
                     ->setMaxLength(5)
                     ->addExtraClass('flexbox-area-grow'),
-                TextField::create(
+                NumericField::create(
                     'Height',
                     _t('SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.ImageHeight', 'Height')
                 )
@@ -98,7 +99,7 @@ class ImageFormFactory extends FileFormFactory
      */
     public function getForm(RequestHandler $controller = null, $name = FormFactory::DEFAULT_NAME, $context = [])
     {
-        $this->beforeExtending('updateForm', function ($form) use ($context) {
+        $this->beforeExtending('updateForm', function (Form $form) use ($context) {
             $record = null;
             if (isset($context['Record'])) {
                 $record = $context['Record'];
@@ -131,6 +132,30 @@ class ImageFormFactory extends FileFormFactory
             }
         });
 
-        return parent::getForm($controller, $name, $context);
+        $form = parent::getForm($controller, $name, $context);
+        // Set Width and Height to Insert dimensions if available.
+        if ($context['Record'] && $dimensions = $this->getInsertDimensions($context['Record'])) {
+            $form->loadDataFrom($dimensions);
+        }
+        return $form;
+    }
+
+    /**
+     * Retrieve the approprite insert dimension for the image, if available.
+     * @param Image $context
+     * @return array|false
+     */
+    private function getInsertDimensions($context)
+    {
+        if ($context &&
+            $context->hasMethod('getInsertWidth') &&
+            $context->hasMethod('getInsertHeight')
+        ) {
+            return [
+                'Width' => $context->getInsertWidth(),
+                'Height' => $context->getInsertHeight(),
+            ];
+        }
+        return false;
     }
 }

--- a/tests/php/Forms/ImageFormFactoryTest.php
+++ b/tests/php/Forms/ImageFormFactoryTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace SilverStripe\AssetAdmin\Tests\Forms;
+
+use SilverStripe\AssetAdmin\Controller\AssetAdmin;
+use SilverStripe\AssetAdmin\Forms\AssetFormFactory;
+use SilverStripe\AssetAdmin\Forms\ImageFormFactory;
+use SilverStripe\AssetAdmin\Forms\UploadField;
+use SilverStripe\AssetAdmin\Tests\Forms\FileFormBuilderTest\FileOwner;
+use SilverStripe\Assets\File;
+use SilverStripe\Assets\Image;
+use Silverstripe\Assets\Dev\TestAssetStore;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\Form;
+use SilverStripe\Forms\FormFactory;
+use SilverStripe\ORM\ArrayList;
+
+/**
+ * @skipUpgrade
+ */
+class ImageFormFactoryTest extends SapphireTest
+{
+    /** @var Image */
+    private $img;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        // Set backend and base url
+        TestAssetStore::activate('ImageFormFactoryTest');
+
+        $img = Image::create();
+        $img->setFromLocalFile(__DIR__ . '/fixtures/largeimage.png', 'files/largeimage.png');
+        $img->write();
+
+        $this->img = $img;
+    }
+
+    public function tearDown()
+    {
+        TestAssetStore::reset();
+        parent::tearDown();
+    }
+
+    /**
+     * @param int $insertWidth
+     * @param int $insertHeight
+     * @param int $expectedWidth
+     * @param int $expectedHeight
+     * @dataProvider insertSizeDataProvider
+     */
+    public function testInsertImageSize($insertWidth, $insertHeight, $expectedWidth, $expectedHeight)
+    {
+        $config = $this->img::config();
+        $config->set('insert_width', $insertWidth);
+        $config->set('insert_height', $insertHeight);
+
+        $form = ImageFormFactory::create()->getForm(
+            null,
+            'fileInsertForm',
+            ['Type' => AssetFormFactory::TYPE_INSERT_MEDIA , 'Record' => $this->img, 'RequireLinkText' => true]
+        );
+        $data = $form->getData();
+        $this->assertEquals($expectedWidth, $data['Width']);
+        $this->assertEquals($expectedHeight, $data['Height']);
+    }
+
+    public function insertSizeDataProvider()
+    {
+        // The image we're using for testing is 600x400
+        return [
+            'Default setting' => [600, 400, 600, 400],
+            'Insert height smaller than image' => [600, 398, 597, 398],
+            'Insert width half of image' => [597, 400, 597, 398],
+            'Insert dimensions greater than image' => [603, 402, 600, 400],
+        ];
+    }
+}

--- a/tests/php/Forms/ImageFormFactoryTest.php
+++ b/tests/php/Forms/ImageFormFactoryTest.php
@@ -54,7 +54,7 @@ class ImageFormFactoryTest extends SapphireTest
      */
     public function testInsertImageSize($insertWidth, $insertHeight, $expectedWidth, $expectedHeight)
     {
-        $config = $this->img::config();
+        $config = Image::config();
         $config->set('insert_width', $insertWidth);
         $config->set('insert_height', $insertHeight);
 

--- a/tests/php/Forms/ImageFormFactoryTest.php
+++ b/tests/php/Forms/ImageFormFactoryTest.php
@@ -25,6 +25,8 @@ class ImageFormFactoryTest extends SapphireTest
     /** @var Image */
     private $img;
 
+    protected $usesDatabase = true;
+
     protected function setUp()
     {
         parent::setUp();


### PR DESCRIPTION
This updates ImageFormFactory to respect the default insert_width and insert_height dimension.

# Parent issue
* #917

# Supersedes
* #1013 