### PR TITLE
NEW Add tip to Alt Text field in Insert Media dialog

### DIFF
--- a/code/Forms/ImageFormFactory.php
+++ b/code/Forms/ImageFormFactory.php
@@ -12,6 +12,8 @@ use SilverStripe\Forms\NumericField;
 use SilverStripe\Forms\OptionsetField;
 use SilverStripe\Forms\Tab;
 use SilverStripe\Forms\TextField;
+use SilverStripe\Forms\Tip;
+use SilverStripe\Forms\TippableFieldInterface;
 
 class ImageFormFactory extends FileFormFactory
 {
@@ -77,19 +79,41 @@ class ImageFormFactory extends FileFormFactory
 
         $tab->insertAfter(
             'Caption',
-            TextField::create('AltText', _t('SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.AltText', 'Alternative text (alt)'))
-                ->setDescription(_t(
-                    'SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.AltTextDescription',
-                    'Shown to screen readers or if image can\'t be displayed'
-                ))
+            $altTextField = TextField::create(
+                'AltText',
+                _t('SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.AltText', 'Alternative text (alt)')
+            )
+        );
+
+        $altTextDescription = _t(
+            'SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.AltTextDescription',
+            implode(
+                ' ',
+                [
+                    'Description for visitors who are unable to view the image (using screenreaders or',
+                    'image blockers). Recommended for images which provide unique context to the content.'
+                ]
+            )
         );
 
         $tab->insertAfter(
             'AltText',
-            TextField::create('TitleTooltip', _t('SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.TitleTooltip', 'Title text (tooltip)'))
-                ->setDescription(_t('SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.TitleTooltipDescription', 'For additional information about the image'))
+            $titleField = TextField::create('TitleTooltip', _t('SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.TitleTooltip', 'Title text (tooltip)'))
                 ->setValue($record->Title)
         );
+
+        $titleDescription = _t(
+            'SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.TitleTooltipDescription',
+            'Provides a long form explanation if required. Shown on hover.'
+        );
+
+        if ($altTextField instanceof TippableFieldInterface) {
+            $altTextField->setTip(new Tip($altTextDescription, Tip::IMPORTANCE_LEVELS['HIGH']));
+            $titleField->setTip(new Tip($titleDescription, Tip::IMPORTANCE_LEVELS['NORMAL']));
+        } else {
+            $altTextField->setDescription($altTextDescription);
+            $titleField->setDescription($titleDescription);
+        }
 
         return $tab;
     }

--- a/code/Forms/ImageFormFactory.php
+++ b/code/Forms/ImageFormFactory.php
@@ -86,24 +86,23 @@ class ImageFormFactory extends FileFormFactory
         );
 
         $altTextDescription = _t(
-            'SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.AltTextDescription',
-            implode(
-                ' ',
-                [
-                    'Description for visitors who are unable to view the image (using screenreaders or',
-                    'image blockers). Recommended for images which provide unique context to the content.'
-                ]
-            )
+            'SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.AltTextTip',
+            implode([
+                'Description for visitors who are unable to view the image (using screenreaders or ',
+                'image blockers). Recommended for images which provide unique context to the content.',
+            ])
         );
 
         $tab->insertAfter(
             'AltText',
-            $titleField = TextField::create('TitleTooltip', _t('SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.TitleTooltip', 'Title text (tooltip)'))
-                ->setValue($record->Title)
+            $titleField = TextField::create(
+                'TitleTooltip',
+                _t('SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.TitleTooltip', 'Title text (tooltip)')
+            )->setValue($record->Title)
         );
 
         $titleDescription = _t(
-            'SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.TitleTooltipDescription',
+            'SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.TitleTooltipTip',
             'Provides a long form explanation if required. Shown on hover.'
         );
 

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -19,7 +19,7 @@ en:
     AlignmentRight: 'Right wrap'
     AlignmentRightAlone: Right
     AltText: 'Alternative text (alt)'
-    AltTextDescription: 'Shown to screen readers or if image can''t be displayed'
+    AltTextDescription: 'Description for visitors who are unable to view the image (using screenreaders or image blockers). Recommended for images which provide unique context to the content.'
     AppCategoryArchive: Archive
     AppCategoryAudio: Audio
     AppCategoryDocument: Document
@@ -51,7 +51,7 @@ en:
     Placement: Placement
     SAVEDFILE: 'Saved file'
     TitleTooltip: 'Title text (tooltip)'
-    TitleTooltipDescription: 'For additional information about the image'
+    TitleTooltipDescription: 'Provides a long form explanation if required. Shown on hover.'
     UNKNOWN: Unknown
     UNPUBLISH_BUTTON: Unpublish
     UPLOADEDFILE: 'Uploaded file'

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -19,7 +19,7 @@ en:
     AlignmentRight: 'Right wrap'
     AlignmentRightAlone: Right
     AltText: 'Alternative text (alt)'
-    AltTextDescription: 'Description for visitors who are unable to view the image (using screenreaders or image blockers). Recommended for images which provide unique context to the content.'
+    AltTextTip: 'Description for visitors who are unable to view the image (using screenreaders or image blockers). Recommended for images which provide unique context to the content.'
     AppCategoryArchive: Archive
     AppCategoryAudio: Audio
     AppCategoryDocument: Document
@@ -51,7 +51,7 @@ en:
     Placement: Placement
     SAVEDFILE: 'Saved file'
     TitleTooltip: 'Title text (tooltip)'
-    TitleTooltipDescription: 'Provides a long form explanation if required. Shown on hover.'
+    TitleTooltipTip: 'Provides a long form explanation if required. Shown on hover.'
     UNKNOWN: Unknown
     UNPUBLISH_BUTTON: Unpublish
     UPLOADEDFILE: 'Uploaded file'


### PR DESCRIPTION
Applies tips to the Alt Text and Title Tooltip fields in the Insert Media dialog, or falls back to descriptions if tips aren't available.

Resolves #983.