### PR TITLE
Stop an image's "Title text (tooltip)" being set to the filename

### DIFF
--- a/code/Forms/ImageFormFactory.php
+++ b/code/Forms/ImageFormFactory.php
@@ -98,7 +98,7 @@ class ImageFormFactory extends FileFormFactory
             $titleField = TextField::create(
                 'TitleTooltip',
                 _t('SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.TitleTooltip', 'Title text (tooltip)')
-            )->setValue($record->Title)
+            )
         );
 
         $titleDescription = _t(


### PR DESCRIPTION
When any image is inserted into the WYSIWYG, it sets the "Title text (tooltip)" field to the image's Title, which is usually just it's filename. This isn't desired or useful in most cases, and usually results in ugly tooltips such as "IMG12345" or "image34" appearing when site visitors hover over an image.

This PR stops the "Title text" being set automatically, to ensure that any tooltips are added on purpose.

Resolves: https://github.com/silverstripe/silverstripe-assets/issues/129