### PR TITLE
BUG Tweak UsedOnTableTest to dynamically switch protocol

### DIFF
--- a/tests/php/Forms/UsedOnTableTest.php
+++ b/tests/php/Forms/UsedOnTableTest.php
@@ -4,6 +4,7 @@ namespace SilverStripe\AssetAdmin\Tests\Forms;
 
 use SilverStripe\Admin\Forms\UsedOnTable;
 use SilverStripe\Assets\File;
+use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\SapphireTest;
 
@@ -22,7 +23,17 @@ class UsedOnTableTest extends SapphireTest
 
         $response = $usedOnTable->usage(new HTTPRequest("GET", "/"));
 
-        $expected = '{"usage":[{"id":0,"title":"My Page","type":"Page","state":"Draft","link":"http:\/\/localhost\/admin\/pages\/edit\/show\/1"}]}';
+        $protocol = Director::is_https() ? 'https' : 'http';
+
+        $expected = json_encode([
+            "usage"=> [[
+                "id" => 0,
+                "title" => "My Page",
+                "type" => "Page",
+                "state" => "Draft",
+                "link" => sprintf('%s://localhost/admin/pages/edit/show/1', $protocol)
+            ]]
+        ]);
         $this->assertEquals($expected, $response->getBody());
     }
 }


### PR DESCRIPTION
This test occasionally fails because it expect the protocol to always be HTTP. I've added a is_https check to swap protocol.