### PR TITLE
FIX Handle case where provided $context is null

### DIFF
--- a/code/GraphQL/CreateFolderMutationCreator.php
+++ b/code/GraphQL/CreateFolderMutationCreator.php
@@ -69,7 +69,7 @@ class CreateFolderMutationCreator extends MutationCreator implements OperationRe
         foreach ($args['folder'] as $name => $val) {
             $canCreateContext[$this->accessor->getObjectFieldName(Folder::singleton(), $name)] = $val;
         }
-        if (!Folder::singleton()->canCreate($context['currentUser'], $canCreateContext)) {
+        if (!Folder::singleton()->canCreate($context['currentUser'] ?? null, $canCreateContext)) {
             throw new \InvalidArgumentException(sprintf(
                 '%s create not allowed',
                 Folder::class


### PR DESCRIPTION
Previously PHP would silently resolve the incorrect array access to null, but as of 7.4 this throws an error.