### PR TITLE
BUG: Campaign admin permission fix

### DIFF
--- a/code/Extensions/CampaignAdminExtension.php
+++ b/code/Extensions/CampaignAdminExtension.php
@@ -5,6 +5,7 @@ namespace SilverStripe\AssetAdmin\Extensions;
 use SilverStripe\Assets\File;
 use SilverStripe\Core\Extension;
 use SilverStripe\Forms\FormAction;
+use SilverStripe\Security\Permission;
 
 /**
  * Extension that updates the Popover menu of `FileFormFactory`.
@@ -21,6 +22,10 @@ class CampaignAdminExtension extends Extension
      */
     public function updatePopoverActions(&$actions, $record)
     {
+        if (!Permission::check('CMS_ACCESS_CampaignAdmin')) {
+            return;
+        }
+
         if ($record && $record->canPublish()) {
             $action = FormAction::create(
                 'addtocampaign',


### PR DESCRIPTION
## Campaign admin permission fix

* Add to campaign widget is no longer displayed for users which don't have permission to access campaign admin functionality
* This makes the edit form behaviour consistent with Page edit form

## Related issues

https://github.com/silverstripe/silverstripe-asset-admin/issues/1076