### PR TITLE
BUG Always sort files with folders first

### DIFF
--- a/client/src/state/gallery/GalleryReducer.js
+++ b/client/src/state/gallery/GalleryReducer.js
@@ -18,7 +18,7 @@ const initialState = {
    */
   sorters: [
     {
-      field: 'title',
+      field: 'name',
       direction: 'asc',
       label: i18n._t('AssetAdmin.FILTER_TITLE_ASC', 'title a-z'),
     },

--- a/code/GraphQL/FolderTypeCreator.php
+++ b/code/GraphQL/FolderTypeCreator.php
@@ -109,7 +109,7 @@ class FolderTypeCreator extends FileTypeCreator
      */
     public function getChildrenConnection()
     {
-        return Connection::create('Children')
+        return ReadFileConnection::create('Children')
             ->setConnectionType(function () {
                 return $this->manager->getType('FileInterface');
             })
@@ -125,6 +125,7 @@ class FolderTypeCreator extends FileTypeCreator
                 'title' => 'Title',
                 'created' => 'Created',
                 'lastEdited' => 'LastEdited',
+                'name' => 'Name'
                 // TODO Make memory-based size search efficient enough for 10k records
                 //size' => 'Size'
             ]);

--- a/code/GraphQL/ReadFileConnection.php
+++ b/code/GraphQL/ReadFileConnection.php
@@ -1,0 +1,50 @@
+<?php
+namespace SilverStripe\AssetAdmin\GraphQL;
+
+use SilverStripe\Assets\Folder;
+use SilverStripe\GraphQL\Pagination\Connection;
+use SilverStripe\ORM\DataQuery;
+use SilverStripe\ORM\DB;
+
+class ReadFileConnection extends Connection
+{
+
+    protected function applySort($list, $sortBy)
+    {
+        $list = parent::applySort($list, $sortBy);
+
+
+        $list = $list->alterDataQuery(static function (DataQuery $dataQuery) {
+            $query = $dataQuery->query();
+            $existingOrderBys = [];
+            foreach ($query->getOrderBy() as $field => $direction) {
+                if (strpos($field, '.') === false) {
+                    // some fields may be surrogates added by extending augmentSQL
+                    // we have to preserve those expressions rather than auto-generated names
+                    // that SQLSelect::addOrderBy leaves for them (e.g. _SortColumn0)
+                    $field = $query->expressionForField(trim($field, '"')) ?: $field;
+                }
+
+                $existingOrderBys[$field] = $direction;
+            }
+
+            // Folders should always go first
+            $dataQuery->sort(
+                sprintf(
+                    '(CASE WHEN "ClassName"=%s THEN 1 ELSE 0 END)',
+                    DB::get_conn()->quoteString(Folder::class)
+                ),
+                'DESC',
+                true
+            );
+
+            foreach ($existingOrderBys as $field => $dir) {
+                $dataQuery->sort($field, $dir, false);
+            }
+
+            return $dataQuery;
+        });
+
+        return $list;
+    }
+}

--- a/code/GraphQL/ReadFileQueryCreator.php
+++ b/code/GraphQL/ReadFileQueryCreator.php
@@ -23,7 +23,7 @@ class ReadFileQueryCreator extends PaginatedQueryCreator
 
     public function createConnection()
     {
-        return Connection::create('readFiles')
+        return ReadFileConnection::create('readFiles')
             ->setConnectionType(function () {
                 return new UnionType([
                     'name' => 'Result',


### PR DESCRIPTION
This is my go at fixing https://github.com/silverstripe/silverstripe-asset-admin/issues/1108

It's somewhat dodgy in that it relies on extending the native connection with our own ReadFileConnection so we can give it a different applySort method.