### PR TITLE
GraphQL BACKWARD_COMPAT flag fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ before_script:
   - composer validate
   - if [[ $DB == PGSQL ]]; then composer require --no-update silverstripe/postgresql:2.x-dev --prefer-dist; fi
   - composer require silverstripe/recipe-testing:^1 silverstripe/recipe-cms:4.x-dev silverstripe/frameworktest:4.x-dev --no-update --prefer-dist
-  - 'if [[ ! $BACKWARD_COMPAT ]]; then composer require silverstripe/graphql:4.x-dev --no-update; fi'
+  - 'if [[ $BACKWARD_COMPAT ]]; then composer require silverstripe/graphql:3.x-dev --no-update; fi'
   - composer update $COMPOSER_ARG
 
 


### PR DESCRIPTION
It assumed the defaults would pull in silverstripe/graphql:3,
but due to the loosened constraints ("3 || 4") it pulls in silverstripe/graphql:4.