### PR TITLE
NEW: Compatibility with GraphQL 4 changes

### DIFF
--- a/_config/graphql.yml
+++ b/_config/graphql.yml
@@ -8,3 +8,11 @@ SilverStripe\GraphQL\Schema\Schema:
     admin:
       src:
         assetAdmin: 'silverstripe/asset-admin: _graphql'
+
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\EventDispatcher\Dispatch\Dispatcher:
+    properties:
+      handlers:
+        graphqlSchemaBuild:
+          on: [ graphqlSchemaBuild.admin ]
+          handler: '%$SilverStripe\GraphQL\Schema\Services\SchemaTranscribeHandler'

--- a/_config/graphql.yml
+++ b/_config/graphql.yml
@@ -8,11 +8,3 @@ SilverStripe\GraphQL\Schema\Schema:
     admin:
       src:
         assetAdmin: 'silverstripe/asset-admin: _graphql'
-
-SilverStripe\Core\Injector\Injector:
-  SilverStripe\EventDispatcher\Dispatch\Dispatcher:
-    properties:
-      handlers:
-        graphqlSchemaBuild:
-          on: [ graphqlSchemaBuild.admin ]
-          handler: '%$SilverStripe\GraphQL\Schema\Services\SchemaTranscribeHandler'

--- a/_graphql/types/Folder.yml
+++ b/_graphql/types/Folder.yml
@@ -29,6 +29,7 @@ Folder:
       plugins:
         sorter:
           input: FolderChildrenSortFields
+          resolver: [SilverStripe\AssetAdmin\GraphQL\Resolvers\FolderTypeResolver, sortChildren]
           fields:
             id: ID
             title: Title

--- a/code/GraphQL/Resolvers/AssetAdminResolver.php
+++ b/code/GraphQL/Resolvers/AssetAdminResolver.php
@@ -5,16 +5,12 @@ namespace SilverStripe\AssetAdmin\GraphQL\Resolvers;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use SilverStripe\AssetAdmin\GraphQL\FileFilter;
-use SilverStripe\AssetAdmin\GraphQL\FileFilterInputTypeCreator;
 use SilverStripe\AssetAdmin\GraphQL\Notice;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Folder;
 use SilverStripe\Control\HTTPResponse_Exception;
-use SilverStripe\GraphQL\QueryHandler\QueryHandler;
 use SilverStripe\GraphQL\QueryHandler\UserContextProvider;
 use SilverStripe\GraphQL\Schema\DataObject\FieldAccessor;
-use SilverStripe\GraphQL\Schema\DataObject\Plugin\Paginator;
-use SilverStripe\GraphQL\Schema\Resolver\DefaultResolverProvider;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\Filterable;
 use SilverStripe\Versioned\Versioned;
@@ -300,7 +296,7 @@ class AssetAdminResolver
         $list = FileFilter::filterList($list, $filter);
 
         // Permission checks
-        $list = $list->filterByCallback(function (File $file) use ($context) {
+        $list = $list->filterByCallback(function (File $file) use ($context, $member) {
             return $file->canView($member);
         });
 

--- a/code/GraphQL/Resolvers/FolderTypeResolver.php
+++ b/code/GraphQL/Resolvers/FolderTypeResolver.php
@@ -9,6 +9,7 @@ use SilverStripe\AssetAdmin\GraphQL\FileFilter;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Folder;
 use SilverStripe\GraphQL\QueryHandler\QueryHandler;
+use SilverStripe\GraphQL\QueryHandler\UserContextProvider;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataQuery;
 use SilverStripe\ORM\DB;
@@ -96,9 +97,10 @@ class FolderTypeResolver
         $ids = $list->dataQuery()->execute()->column('ID');
 
         $permissionChecker = File::singleton()->getPermissionChecker();
+        $member = UserContextProvider::get($context);
         $canViewIDs = array_keys(array_filter($permissionChecker->canViewMultiple(
             $ids,
-            $context[QueryHandler::CURRENT_USER]
+            $member
         )));
         // Filter by visible IDs (or force empty set if none are visible)
         // Remove the limit as it no longer applies. We've already filtered down to the exact

--- a/code/GraphQL/Resolvers/FolderTypeResolver.php
+++ b/code/GraphQL/Resolvers/FolderTypeResolver.php
@@ -8,14 +8,17 @@ use SilverStripe\AssetAdmin\Controller\AssetAdminFile;
 use SilverStripe\AssetAdmin\GraphQL\FileFilter;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Folder;
-use SilverStripe\GraphQL\QueryHandler\QueryHandler;
 use SilverStripe\GraphQL\QueryHandler\UserContextProvider;
+use SilverStripe\GraphQL\Schema\DataObject\FieldAccessor;
+use SilverStripe\GraphQL\Schema\Schema;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataQuery;
 use SilverStripe\ORM\DB;
+use SilverStripe\ORM\Sortable;
 use SilverStripe\Versioned\Versioned;
 use InvalidArgumentException;
 use Exception;
+use Closure;
 
 class FolderTypeResolver
 {
@@ -145,4 +148,32 @@ class FolderTypeResolver
 
         return $parents;
     }
+
+    /**
+     * @param array $context
+     * @return Closure
+     */
+    public static function sortChildren(array $context): Closure
+    {
+        $fieldName = $context['fieldName'];
+        return function (?Sortable $list, array $args) use ($fieldName) {
+            if ($list === null) {
+                return null;
+            }
+            $sortArgs = $args[$fieldName] ?? [];
+            foreach ($sortArgs as $field => $dir) {
+                $normalised = FieldAccessor::singleton()->normaliseField(File::singleton(), $field);
+                Schema::invariant(
+                    $normalised,
+                    'Could not find field %s on %s',
+                    $field,
+                    File::class
+                );
+                $list = $list->sort($normalised, $dir);
+            }
+
+            return $list;
+        };
+    }
+
 }

--- a/code/GraphQL/Resolvers/PublicationResolver.php
+++ b/code/GraphQL/Resolvers/PublicationResolver.php
@@ -7,6 +7,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use SilverStripe\AssetAdmin\GraphQL\Notice;
 use SilverStripe\Assets\File;
 use SilverStripe\GraphQL\QueryHandler\QueryHandler;
+use SilverStripe\GraphQL\QueryHandler\UserContextProvider;
 use SilverStripe\Versioned\RecursivePublishable;
 use SilverStripe\Versioned\Versioned;
 use InvalidArgumentException;
@@ -69,7 +70,8 @@ class PublicationResolver
         // Check permissions
         foreach ($files as $file) {
             $permissionMethod = $isPublish ? 'canPublish' : 'canUnpublish';
-            if ($file->$permissionMethod($context[QueryHandler::CURRENT_USER])) {
+            $member = UserContextProvider::get($context);
+            if ($file->$permissionMethod($member)) {
                 $allowedFiles[] = $file;
             } elseif (!$quiet) {
                 $warningMessages[] = sprintf(


### PR DESCRIPTION
## Summary

Use new `UserContextProvider` API, and new sort resolver. Previous sort resolver was relying on something too model-specific, and asset-admin does not use models.


Depends on https://github.com/silverstripe/silverstripe-graphql/pull/352