### PR TITLE
MNT Add frameworktest for behat tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ env:
   global:
     - COMPOSER_ROOT_VERSION="1.x-dev"
     - REQUIRE_RECIPE="4.x-dev"
-    - BEHAT_SUITE=asset-admin
+    - REQUIRE_FRAMEWORKTEST="0.4.2"
+    - BEHAT_SUITE="asset-admin"


### PR DESCRIPTION
Fixes failing behat tests multi/single file upload https://travis-ci.com/github/silverstripe/silverstripe-asset-admin/jobs/484966585#L1911

In travis build for this PR, the failing behat test `tests/behat/features/change-sort-order.feature:12` is [existing](https://travis-ci.com/github/silverstripe/silverstripe-asset-admin/jobs/484966585#L1908) though not fixed