### PR TITLE
#437: Ensure folder names are shown when a user zooms in/out

### DIFF
--- a/client/src/components/GalleryItem/GalleryItem.scss
+++ b/client/src/components/GalleryItem/GalleryItem.scss
@@ -53,7 +53,8 @@ $gallery-item-label-height: 40px;
     padding-top: 17px;
     padding-bottom: 17px;
     padding-left: 0;
-    width: 131px;
+    // We want to take up the space available minus the space taken by gallery-item__thumbnail
+    width: calc(100% - 45px);
     height: $gallery-folder-title-height;
   }
 


### PR DESCRIPTION
This is to resolve: https://github.com/silverstripe/silverstripe-assets/issues/437

Opted to use a relative width rather than a hardcoded one so that it should work at any zoom level