### PR TITLE
ENH Remove duplicate permission check

### DIFF
--- a/_legacy/GraphQL/FolderTypeCreator.php
+++ b/_legacy/GraphQL/FolderTypeCreator.php
@@ -208,26 +208,7 @@ class FolderTypeCreator extends FileTypeCreator
             });
         }
 
-        // Filter by permission
-        // DataQuery::column ignores surrogate sorting fields
-        // see https://github.com/silverstripe/silverstripe-framework/issues/8926
-        // the following line is a workaround for `$ids = $list->column('ID');`
-        $ids = $list->dataQuery()->execute()->column('ID');
-
-        $permissionChecker = File::singleton()->getPermissionChecker();
-        $canViewIDs = array_keys(array_filter($permissionChecker->canViewMultiple(
-            $ids,
-            $context['currentUser']
-        )));
-        // Filter by visible IDs (or force empty set if none are visible)
-        // Remove the limit as it no longer applies. We've already filtered down to the exact
-        // IDs we need.
-        $canViewList = $list->filter('ID', $canViewIDs ?: 0)
-            ->limit(null);
-
-        $result = $childrenConnection->resolveList($list, $args);
-
-        return $result;
+        return $childrenConnection->resolveList($list, $args);
     }
 
     /**


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-assets/issues/447

This PR removes a duplicate permission check from files requested via graphql

The duplicate permission check runs against ALL files in a folder, not just the 50 files that the permission check needs to be run against

Paginated GraphQL results now have canView check run against them in a central place - https://github.com/silverstripe/silverstripe-graphql/blob/3/src/Pagination/Connection.php#L425.  This central permission check happens after a list has been limited to 50.

The asset admin query `readFilesConnection` uses `class ReadFileQueryCreator extends PaginatedQueryCreator` - so results should always be paginated and thus get the permission check in Connection.php

The central checker was added 2 years ago - https://github.com/silverstripe/silverstripe-graphql/blame/3/src/Pagination/Connection.php#L423

The code being removed was originally added 4 years ago, before the central checker existed https://github.com/silverstripe/silverstripe-asset-admin/blame/1/_legacy/GraphQL/FolderTypeCreator.php#L217

Note: the results of the first permission checked weren't even being used, `$canViewList` was (mistakenly?) substituted with the unfiltered `$list` as part of this commit https://github.com/silverstripe/silverstripe-asset-admin/commit/6c3a6197e5bd5bb8f45e007338b4c2c3b4f3a6c6 - this probably was not noticed at the time because it would have passed manual regression testing