### PR TITLE
FIX Always sort by folders first

### DIFF
--- a/_legacy/GraphQL/FolderTypeCreator.php
+++ b/_legacy/GraphQL/FolderTypeCreator.php
@@ -114,7 +114,7 @@ class FolderTypeCreator extends FileTypeCreator
      */
     public function getChildrenConnection()
     {
-        return Connection::create('Children')
+        return ReadFileConnection::create('Children')
             ->setConnectionType(function () {
                 return $this->manager->getType('FileInterface');
             })

--- a/_legacy/GraphQL/ReadFileConnection.php
+++ b/_legacy/GraphQL/ReadFileConnection.php
@@ -1,0 +1,36 @@
+<?php
+namespace SilverStripe\AssetAdmin\GraphQL;
+
+use SilverStripe\Assets\Folder;
+use SilverStripe\GraphQL\Pagination\Connection;
+use SilverStripe\ORM\DataQuery;
+use SilverStripe\ORM\DB;
+use SilverStripe\ORM\SS_List;
+
+if (!class_exists(Connection::class)) {
+    return;
+}
+/**
+ * Connection that sorts by folders first
+ *
+ * @deprecated 1.8 Use silverstripe/graphql:^4 functionality.
+ */
+class ReadFileConnection extends Connection
+{
+    /**
+     * Always sort by folders before files
+     *
+     * @param SS_List $list
+     * @param array $sortBy
+     * @return SS_List
+     */
+    protected function applySort($list, $sortBy)
+    {
+        $className = DB::get_conn()->quoteString(Folder::class);
+        $field = "(CASE WHEN \"ClassName\"={$className} THEN 1 ELSE 0 END)";
+        $sortableFields = $this->getSortableFields();
+        $this->setSortableFields(array_merge([$field => $field], $sortableFields));
+        $updatedSortBy = array_merge([['field' => $field, 'direction' => 'DESC']], $sortBy);
+        return parent::applySort($list, $updatedSortBy);
+    }
+}

--- a/_legacy/GraphQL/ReadFileQueryCreator.php
+++ b/_legacy/GraphQL/ReadFileQueryCreator.php
@@ -33,7 +33,7 @@ class ReadFileQueryCreator extends PaginatedQueryCreator
 
     public function createConnection()
     {
-        return Connection::create('readFiles')
+        return ReadFileConnection::create('readFiles')
             ->setConnectionType(function () {
                 return $this->createResultType();
             })

--- a/code/GraphQL/Resolvers/FolderTypeResolver.php
+++ b/code/GraphQL/Resolvers/FolderTypeResolver.php
@@ -12,7 +12,6 @@ use SilverStripe\GraphQL\QueryHandler\UserContextProvider;
 use SilverStripe\GraphQL\Schema\DataObject\FieldAccessor;
 use SilverStripe\GraphQL\Schema\Schema;
 use SilverStripe\ORM\DataList;
-use SilverStripe\ORM\DataQuery;
 use SilverStripe\ORM\DB;
 use SilverStripe\ORM\Sortable;
 use SilverStripe\Versioned\Versioned;
@@ -55,43 +54,6 @@ class FolderTypeResolver
         $list = Versioned::get_by_stage(File::class, 'Stage');
         $filter['parentId'] = $object->ID;
         $list = FileFilter::filterList($list, $filter);
-
-
-        // Ensure that we're looking at a subset of relevant data.
-        if (!isset($args['sort'])) {
-            // only show folders first if no manual ordering is set
-
-            $list = $list->alterDataQuery(static function (DataQuery $dataQuery) {
-                $query = $dataQuery->query();
-                $existingOrderBys = [];
-                foreach ($query->getOrderBy() as $field => $direction) {
-                    if (strpos($field, '.') === false) {
-                        // some fields may be surrogates added by extending augmentSQL
-                        // we have to preserve those expressions rather than auto-generated names
-                        // that SQLSelect::addOrderBy leaves for them (e.g. _SortColumn0)
-                        $field = $query->expressionForField(trim($field, '"')) ?: $field;
-                    }
-
-                    $existingOrderBys[$field] = $direction;
-                }
-
-                // Folders should always go first
-                $dataQuery->sort(
-                    sprintf(
-                        '(CASE WHEN "ClassName"=%s THEN 1 ELSE 0 END)',
-                        DB::get_conn()->quoteString(Folder::class)
-                    ),
-                    'DESC',
-                    true
-                );
-
-                foreach ($existingOrderBys as $field => $dir) {
-                    $dataQuery->sort($field, $dir, false);
-                }
-
-                return $dataQuery;
-            });
-        }
 
         // Filter by permission
         // DataQuery::column ignores surrogate sorting fields
@@ -160,17 +122,30 @@ class FolderTypeResolver
             if ($list === null) {
                 return null;
             }
+
             $sortArgs = $args[$fieldName] ?? [];
+
+            // ensure that folders appear first
+            $className = DB::get_conn()->quoteString(Folder::class);
+            $classNameField = "(CASE WHEN \"ClassName\"={$className} THEN 1 ELSE 0 END)";
+            $sortArgs = array_merge([$classNameField => 'DESC'], $sortArgs);
+
+            $sort = [];
             foreach ($sortArgs as $field => $dir) {
-                $normalised = FieldAccessor::singleton()->normaliseField(File::singleton(), $field);
+                if ($field == $classNameField) {
+                    $normalised = $classNameField;
+                } else {
+                    $normalised = FieldAccessor::singleton()->normaliseField(File::singleton(), $field);
+                }
                 Schema::invariant(
                     $normalised,
                     'Could not find field %s on %s',
                     $field,
                     File::class
                 );
-                $list = $list->sort($normalised, $dir);
+                $sort[$normalised] = $dir;
             }
+            $list = $list->sort($sort);
 
             return $list;
         };

--- a/tests/behat/features/change-sort-order.feature
+++ b/tests/behat/features/change-sort-order.feature
@@ -4,30 +4,92 @@ Feature: Change view for asset admin
   I want to change the way I'm viewing files
 
   Background:
-    Given a "image" "folder1/file1.jpg"
+    Given a "file" "folder1/document.pdf"
+      And a "image" "folder1/file1.jpg"
       And a "image" "folder1/file2.jpg"
+      # Adding multiple versions of folder/testfile.jpg is intentional
+      # We do this to get paginated results to test that folders
+      # are always at the top of the results that contain normal files and images
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      And a "image" "folder1/testfile.jpg"
+      # subfolder names must start with a letter greater than "t"
+      And a "image" "folder1/xsubfolder1/testfile.jpg"
+      And a "image" "folder1/zsubfolder2/testfile.jpg"
       And I am logged in with "ADMIN" permissions
       And I go to "/admin/assets"
 
-  Scenario: I can switch the sorting order in list view
+  Scenario: I can switch the sorting order in table view
     When I click on the file named "folder1" in the gallery
       And I click on the ".gallery__sort a" element
       And I wait until I see the ".gallery__sort .chosen-results" element
       And I click "Title Z-A" in the ".gallery__sort .chosen-results" element
-    Then I should see the gallery item "file2" in position "1"
-      And I should see the gallery item "file1" in position "2"
+    Then I should see the table gallery folder "zsubfolder2" in position "1"
+      And I should see the table gallery folder "xsubfolder1" in position "2"
+      And I should see the gallery item "testfile v9" in position "1"
+      And I should see the gallery item "testfile v8" in position "2"
     When I click on the ".gallery__sort a" element
       And I wait until I see the ".gallery__sort .chosen-results" element
       And I click "Title A-Z" in the ".gallery__sort .chosen-results" element
-    Then I should see the gallery item "file1" in position "1"
-      And I should see the gallery item "file2" in position "2"
+    Then I should see the table gallery folder "xsubfolder1" in position "1"
+      And I should see the table gallery folder "zsubfolder2" in position "2"
+      And I should see the gallery item "document" in position "1"
+      And I should see the gallery item "file1" in position "2"
 
-  Scenario: I can switch the sorting order in table view
+  Scenario: I can switch the sorting order in list view
     When I click on the file named "folder1" in the gallery
       And I press the "table" button
       And I wait until I see the ".gallery__table-row" element
-    Then I should see the gallery item "file1" in position "1"
-      And I should see the gallery item "file2" in position "2"
+    Then I should see the gallery item "xsubfolder1" in position "1"
+      And I should see the gallery item "zsubfolder2" in position "2"
+      And I should see the gallery item "document" in position "3"
+      And I should see the gallery item "file1" in position "4"
     When I click "Title" in the ".gallery__table thead" element
-    Then I should see the gallery item "file2" in position "1"
-      And I should see the gallery item "file1" in position "2"
+    Then I should see the gallery item "zsubfolder2" in position "1"
+      And I should see the gallery item "xsubfolder1" in position "2"
+      And I should see the gallery item "testfile v9" in position "3"
+      And I should see the gallery item "testfile v8" in position "4"

--- a/tests/behat/src/FixtureContext.php
+++ b/tests/behat/src/FixtureContext.php
@@ -249,7 +249,30 @@ EOS
     }
 
     /**
+     * Helper for finding items in the visible table gallery view by its order
+     *
+     * @param string $rank index of the item to get starting at 1
+     * @return NodeElement
+     */
+    protected function getTableGalleryFolderByRank(string $rank)
+    {
+        /** @var DocumentElement $page */
+        $page = $this->getMainContext()->getSession()->getPage();
+        // Find by cell - folders
+        $cell = $page->find(
+            'xpath',
+            "//div[contains(@class, 'gallery__folders')]/div[$rank]"
+        );
+        if ($cell) {
+            return $cell;
+        }
+        return null;
+    }
+
+    /**
      * Helper for finding items in the visible gallery view by its order
+     *
+     * Note: this does not find folders in table view - use getTableGalleryFolderByRank() for that
      *
      * @param string $rank index of the item to get starting at 1
      * @param int $timeout
@@ -259,7 +282,7 @@ EOS
     {
         /** @var DocumentElement $page */
         $page = $this->getMainContext()->getSession()->getPage();
-        // Find by cell
+        // Find by cell - table view
         $cell = $page->find(
             'xpath',
             "//div[contains(@class, 'gallery__files')]/div[$rank]"
@@ -267,7 +290,7 @@ EOS
         if ($cell) {
             return $cell;
         }
-        // Find by row
+        // Find by row - list view
         $row = $page->find(
             'xpath',
             "//tr[contains(@class, 'gallery__table-row')][$rank]"
@@ -351,6 +374,22 @@ EOS
             "//div//span[contains(text(), '{$name}')]"
         );
         assertNotNull($title, sprintf('File at position %s should be named %s', $position, $name));
+    }
+
+    /**
+     * @Then /^I should see the table gallery folder "([^"]+)" in position "([^"]+)"$/
+     * @param string $name
+     * @param string $position
+     */
+    public function iShouldSeeTheTableGalleryFolderInPosition(string $name, string $position)
+    {
+        $folderByPosition = $this->getTableGalleryFolderByRank($position);
+        assertNotNull($folderByPosition, 'Should have found a gallery folder at position ' . $position);
+        $title = $folderByPosition->find(
+            'xpath',
+            "//div[contains(text(), '{$name}')]"
+        );
+        assertNotNull($title, sprintf('Folder at position %s should be named %s', $position, $name));
     }
 
     /**

--- a/tests/php/GraphQL/FolderTypeCreatorTest.php
+++ b/tests/php/GraphQL/FolderTypeCreatorTest.php
@@ -28,26 +28,6 @@ class FolderTypeCreatorTest extends SapphireTest
         }
     }
 
-    public function testItSortsChildrenOnTypeByDefault()
-    {
-        $rootFolder = Folder::singleton();
-        $file = File::create(['Name' => 'aaa file']);
-        $file->write();
-        $folder = Folder::create(['Name' => 'bbb folder']);
-        $folder->write();
-        $list = $this->resolveChildrenConnection(
-            $rootFolder,
-            []
-        );
-        $this->assertEquals(
-            [
-                $folder->Name,
-                $file->Name,
-            ],
-            $list->column('Name')
-        );
-    }
-
     public function testItDoesNotFilterByParentIdWithRecursiveFlag()
     {
         $rootFolder = Folder::singleton();

--- a/tests/php/GraphQL/Legacy/ReadFileConnectionTest.php
+++ b/tests/php/GraphQL/Legacy/ReadFileConnectionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace SilverStripe\AssetAdmin\Tests\Legacy\GraphQL;
+
+use SilverStripe\AssetAdmin\GraphQL\ReadFileConnection;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\GraphQL\Schema\Schema;
+use SilverStripe\Assets\File;
+
+class ReadFileConnectionTest extends SapphireTest
+{
+    protected static $fixture_file = '../../fixtures.yml';
+
+    protected function setUp()
+    {
+        parent::setUp();
+        if (class_exists(Schema::class)) {
+            $this->markTestSkipped('GraphQL 3 test ' . __CLASS__ . ' skipped');
+        }
+    }
+
+    public function testApplySortFoldersFirst()
+    {
+        $list = File::get();
+
+        $connection = ReadFileConnection::create('readFiles')
+            ->setSortableFields(['Title'])
+            ->setConnectionType(function () {
+                return $this->manager->getType('FileInterface');
+            });
+
+        $result = $connection->resolveList($list, ['sortBy' => [['field' => 'Title', 'direction' => 'ASC']]]);
+        $titles = $result['edges']->column('Title');
+        $this->assertEquals('disallowCanAddChildren', $titles[0]); // disallowCanAddChildren is a folder
+        $this->assertEquals('folder1', $titles[1]);
+        $this->assertEquals('folder1-1', $titles[2]);
+        $this->assertEquals('folder2', $titles[3]);
+        $this->assertEquals('disallowCanDelete', $titles[4]); // disallowCanDelete is a file
+
+        $result = $connection->resolveList($list, ['sortBy' => [['field' => 'Title', 'direction' => 'DESC']]]);
+        $titles = $result['edges']->column('Title');
+        $this->assertEquals('folder2', $titles[0]);
+        $this->assertEquals('folder1-1', $titles[1]);
+        $this->assertEquals('folder1', $titles[2]);
+        $this->assertEquals('disallowCanAddChildren', $titles[3]);
+        $this->assertEquals('The Third File', $titles[4]);
+    }
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-asset-admin/issues/1108

Original PR for ReadFileConnection of https://github.com/silverstripe/silverstripe-asset-admin/pull/1134
Original PR with behat tests https://github.com/silverstripe/silverstripe-asset-admin/pull/1130

For the GraphQL 3, I tried a few different approaches of getting the sort to be done in a non-connection class, though in the end, because applySort() is a protected method and we need to add a non-standard sort, it's hard to do much else short of modifying the graphql module (which I really don't want to do)

The GraphQL 4 version has no unit test, as there are currently no unit tests for resolvers in general for GraphQL 4 in asset-admin.  The new functionality is still covered by the updated behat test
