### PR TITLE
Thumbnail image size improvements

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -52,4 +52,4 @@ SilverStripe\Core\Injector\Injector:
   SilverStripe\AssetAdmin\Model\ThumbnailGenerator.graphql:
     class: SilverStripe\AssetAdmin\Model\ThumbnailGenerator
     properties:
-      Generates: false
+      Generates: true

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -52,4 +52,4 @@ SilverStripe\Core\Injector\Injector:
   SilverStripe\AssetAdmin\Model\ThumbnailGenerator.graphql:
     class: SilverStripe\AssetAdmin\Model\ThumbnailGenerator
     properties:
-      Generates: true
+      Generates: false

--- a/code/Forms/UploadField.php
+++ b/code/Forms/UploadField.php
@@ -42,13 +42,13 @@ class UploadField extends FormField implements FileHandleField
      * @config
      * @var int
      */
-    private static $thumbnail_width = 60;
+    private static $thumbnail_width = 120;
 
     /**
      * @config
      * @var int
      */
-    private static $thumbnail_height = 60;
+    private static $thumbnail_height = 120;
 
     /**
      * Set if uploading new files is enabled.

--- a/code/Model/ThumbnailGenerator.php
+++ b/code/Model/ThumbnailGenerator.php
@@ -63,7 +63,7 @@ class ThumbnailGenerator
      * @var string
      * @config
      */
-    private static $method = 'FitMax';
+    private static $method = 'Fill';
 
     /**
      * Generate thumbnail and return the "src" property for this thumbnail

--- a/tests/php/GraphQL/FileTypeCreatorTest.php
+++ b/tests/php/GraphQL/FileTypeCreatorTest.php
@@ -49,28 +49,22 @@ class FileTypeCreatorTest extends SapphireTest
         $image->setFromLocalFile(__DIR__.'/../Forms/fixtures/largeimage.png', 'TestImage.png');
         $image->write();
 
-        // Image original is unset
-        $thumbnail = FileTypeResolver::resolveFileThumbnail($image, [], [], null);
-        $this->assertNull($thumbnail);
-
-        // Generate thumbnails by viewing this file's data
-        $assetAdmin->getObjectFromData($image, false);
-
+        // Image original is NOT unset - we generate as soon as we request information about the file.
         // protected image should have inline thumbnail
         $thumbnail = FileTypeResolver::resolveFileThumbnail($image, [], [], null);
-        $this->assertStringStartsWith('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAWAAAADr', $thumbnail);
+        $this->assertStringStartsWith('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAWAAAAEI', $thumbnail);
 
         // public image should have url
         $image->publishSingle();
         $thumbnail = FileTypeResolver::resolveFileThumbnail($image, [], [], null);
-        $this->assertEquals('/assets/FileTypeCreatorTest/TestImage__FitMaxWzM1MiwyNjRd.png', $thumbnail);
+        $this->assertEquals('/assets/FileTypeCreatorTest/TestImage__FillWzM1MiwyNjRd.png', $thumbnail);
 
         // Public assets can be set to inline
         ThumbnailGenerator::config()->merge('thumbnail_links', [
             AssetStore::VISIBILITY_PUBLIC => ThumbnailGenerator::INLINE,
         ]);
         $thumbnail = FileTypeResolver::resolveFileThumbnail($image, [], [], null);
-        $this->assertStringStartsWith('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAWAAAADr', $thumbnail);
+        $this->assertStringStartsWith('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAWAAAAEI', $thumbnail);
 
         // Protected assets can be set to url
         // This uses protected asset adapter, so not direct asset link
@@ -79,6 +73,6 @@ class FileTypeCreatorTest extends SapphireTest
         ]);
         $image->doUnpublish();
         $thumbnail = FileTypeResolver::resolveFileThumbnail($image, [], [], null);
-        $this->assertEquals('/assets/8cf6c65fa7/TestImage__FitMaxWzM1MiwyNjRd.png', $thumbnail);
+        $this->assertEquals('/assets/8cf6c65fa7/TestImage__FillWzM1MiwyNjRd.png', $thumbnail);
     }
 }

--- a/tests/php/GraphQL/FileTypeCreatorTest.php
+++ b/tests/php/GraphQL/FileTypeCreatorTest.php
@@ -49,7 +49,13 @@ class FileTypeCreatorTest extends SapphireTest
         $image->setFromLocalFile(__DIR__.'/../Forms/fixtures/largeimage.png', 'TestImage.png');
         $image->write();
 
-        // Image original is NOT unset - we generate as soon as we request information about the file.
+        // Image original is unset
+        $thumbnail = FileTypeResolver::resolveFileThumbnail($image, [], [], null);
+        $this->assertNull($thumbnail);
+
+        // Generate thumbnails by viewing this file's data
+        $assetAdmin->getObjectFromData($image, false);
+
         // protected image should have inline thumbnail
         $thumbnail = FileTypeResolver::resolveFileThumbnail($image, [], [], null);
         $this->assertStringStartsWith('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAWAAAAEI', $thumbnail);

--- a/tests/php/GraphQL/Legacy/FileTypeCreatorTest.php
+++ b/tests/php/GraphQL/Legacy/FileTypeCreatorTest.php
@@ -50,28 +50,22 @@ class FileTypeCreatorTest extends SapphireTest
         $image->setFromLocalFile(__DIR__.'/../../Forms/fixtures/largeimage.png', 'TestImage.png');
         $image->write();
 
-        // Image original is unset
-        $thumbnail = $type->resolveThumbnailField($image, [], [], null);
-        $this->assertNull($thumbnail);
-
-        // Generate thumbnails by viewing this file's data
-        $assetAdmin->getObjectFromData($image, false);
-
+        // Image original is NOT unset - we generate as soon as we request information about the file.
         // protected image should have inline thumbnail
         $thumbnail = $type->resolveThumbnailField($image, [], [], null);
-        $this->assertStringStartsWith('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAWAAAADr', $thumbnail);
+        $this->assertStringStartsWith('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAWAAAAEI', $thumbnail);
 
         // public image should have url
         $image->publishSingle();
         $thumbnail = $type->resolveThumbnailField($image, [], [], null);
-        $this->assertEquals('/assets/FileTypeCreatorTest/TestImage__FitMaxWzM1MiwyNjRd.png', $thumbnail);
+        $this->assertEquals('/assets/FileTypeCreatorTest/TestImage__FillWzM1MiwyNjRd.png', $thumbnail);
 
         // Public assets can be set to inline
         ThumbnailGenerator::config()->merge('thumbnail_links', [
             AssetStore::VISIBILITY_PUBLIC => ThumbnailGenerator::INLINE,
         ]);
         $thumbnail = $type->resolveThumbnailField($image, [], [], null);
-        $this->assertStringStartsWith('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAWAAAADr', $thumbnail);
+        $this->assertStringStartsWith('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAWAAAAEI', $thumbnail);
 
         // Protected assets can be set to url
         // This uses protected asset adapter, so not direct asset link
@@ -80,6 +74,6 @@ class FileTypeCreatorTest extends SapphireTest
         ]);
         $image->doUnpublish();
         $thumbnail = $type->resolveThumbnailField($image, [], [], null);
-        $this->assertEquals('/assets/8cf6c65fa7/TestImage__FitMaxWzM1MiwyNjRd.png', $thumbnail);
+        $this->assertEquals('/assets/8cf6c65fa7/TestImage__FillWzM1MiwyNjRd.png', $thumbnail);
     }
 }

--- a/tests/php/GraphQL/Legacy/FileTypeCreatorTest.php
+++ b/tests/php/GraphQL/Legacy/FileTypeCreatorTest.php
@@ -49,8 +49,13 @@ class FileTypeCreatorTest extends SapphireTest
         $image = new Image();
         $image->setFromLocalFile(__DIR__.'/../../Forms/fixtures/largeimage.png', 'TestImage.png');
         $image->write();
+        // Image original is unset
+        $thumbnail = $type->resolveThumbnailField($image, [], [], null);
+        $this->assertNull($thumbnail);
 
-        // Image original is NOT unset - we generate as soon as we request information about the file.
+        // Generate thumbnails by viewing this file's data
+        $assetAdmin->getObjectFromData($image, false);
+
         // protected image should have inline thumbnail
         $thumbnail = $type->resolveThumbnailField($image, [], [], null);
         $this->assertStringStartsWith('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAWAAAAEI', $thumbnail);

--- a/tests/php/Model/ThumbnailGeneratorTest.php
+++ b/tests/php/Model/ThumbnailGeneratorTest.php
@@ -39,7 +39,7 @@ class ThumbnailGeneratorTest extends SapphireTest
         // protected image should have inline thumbnail
         $thumbnail = $generator->generateThumbnail($image, 100, 200);
         $this->assertEquals(100, $thumbnail->getWidth());
-        $this->assertEquals(50, $thumbnail->getHeight()); // Note: Aspect ratio of original image retained
+        $this->assertEquals(200, $thumbnail->getHeight());
 
         // Build non-image
         $file = new File();
@@ -55,6 +55,20 @@ class ThumbnailGeneratorTest extends SapphireTest
         $image->write();
         $thumbnail = $generator->generateThumbnail($image, 100, 200);
         $this->assertNull($thumbnail);
+    }
+
+    public function testGenerateThumbnailFitMax()
+    {
+        ThumbnailGenerator::config()->set('method', 'FitMax');
+        $generator = new ThumbnailGenerator();
+        // Build image
+        $image = new Image();
+        $image->setFromLocalFile(__DIR__ . '/../Forms/fixtures/testimage.png', 'TestImage.png');
+        $image->write();
+
+        $thumbnail = $generator->generateThumbnail($image, 100, 200);
+        $this->assertEquals(100, $thumbnail->getWidth());
+        $this->assertEquals(50, $thumbnail->getHeight()); // Note: Aspect ratio of original image retained
     }
 
     public function testGenerateLink()
@@ -82,7 +96,7 @@ class ThumbnailGeneratorTest extends SapphireTest
 
         // protected image should have inline thumbnail
         $thumbnail = $generator->generateThumbnailLink($image, 100, 200);
-        $this->assertStringStartsWith('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAAAy', $thumbnail);
+        $this->assertStringStartsWith('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAADI', $thumbnail);
 
         // but not if it's too big
         Config::nest();
@@ -92,20 +106,20 @@ class ThumbnailGeneratorTest extends SapphireTest
         $this->assertNull($thumbnail);
         // With graceful thumbnails, it should come back as a URL
         $thumbnail = $generator->generateThumbnailLink($image, 100, 200, true);
-        $this->assertMatchesRegularExpression('#/assets/[A-Za-z0-9]+/TestImage__FitMaxWzEwMCwyMDBd\.png$#', $thumbnail);
+        $this->assertMatchesRegularExpression('#/assets/[A-Za-z0-9]+/TestImage__FillWzEwMCwyMDBd\.png$#', $thumbnail);
         Config::unnest();
 
         // public image should have url
         $image->publishSingle();
         $thumbnail = $generator->generateThumbnailLink($image, 100, 200);
-        $this->assertEquals('/assets/ThumbnailGeneratorTest/TestImage__FitMaxWzEwMCwyMDBd.png', $thumbnail);
+        $this->assertEquals('/assets/ThumbnailGeneratorTest/TestImage__FillWzEwMCwyMDBd.png', $thumbnail);
 
         // Public assets can be set to inline
         ThumbnailGenerator::config()->merge('thumbnail_links', [
             AssetStore::VISIBILITY_PUBLIC => ThumbnailGenerator::INLINE,
         ]);
         $thumbnail = $generator->generateThumbnailLink($image, 100, 200);
-        $this->assertStringStartsWith('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAAAy', $thumbnail);
+        $this->assertStringStartsWith('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAADI', $thumbnail);
 
         // Protected assets can be set to url
         // This uses protected asset adapter, so not direct asset link
@@ -114,6 +128,6 @@ class ThumbnailGeneratorTest extends SapphireTest
         ]);
         $image->doUnpublish();
         $thumbnail = $generator->generateThumbnailLink($image, 100, 200);
-        $this->assertEquals('/assets/906835357d/TestImage__FitMaxWzEwMCwyMDBd.png', $thumbnail);
+        $this->assertEquals('/assets/906835357d/TestImage__FillWzEwMCwyMDBd.png', $thumbnail);
     }
 }


### PR DESCRIPTION
Issue: https://github.com/silverstripe/silverstripe-asset-admin/issues/1228

This PR corrects thumbnail image sizes to ensure they are crisp and not blurry.

Thumbnails are typically displayed at a consistent size, yet, `ThumbnailGenerator` currently uses the `FitMax` resize method, which results in differently sized images. These are then currently resized and cropped in CSS (using `background-size: cover`) to make them display at a consistent size. However, due to `FitMax` this results in nearly all thumbnails being upscaled and thus displaying blurrier than they should. Very wide or tall images are most affected by this, especially in `UploadField` thumbnails.

This PR changes the default `ThumbnailGenerator` resize method from `FitMax` to `Fill` so that the resulting image is exactly the desired size, and no upscaling in CSS is necessary.

~~**NOTE: After this change, it is necessary to run `./vendor/bin/sake dev/tasks/MigrateFileTask generate-cms-thumbnails` to re-create the CMS thumbnails, otherwise NO thumbnails will display in the "Files" area. Open to suggestions for making this an optional change for existing sites.**~~

The default thumbnail dimensions for `UploadField` are also doubled from `60` to `120` to ensure `UploadField` thumbnails remain crisp on HiDPI displays.