### PR TITLE
FIX file history not displaying

### DIFF
--- a/code/Controller/AssetAdminFile.php
+++ b/code/Controller/AssetAdminFile.php
@@ -119,8 +119,10 @@ class AssetAdminFile extends DataExtension
             return _t('SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.UPLOADEDFILE', "Uploaded file");
         }
 
-        $fromRecord = Versioned::get_version(get_class($this->owner), $this->owner->ID, $from);
-        $toRecord = Versioned::get_version(get_class($this->owner), $this->owner->ID, $to);
+        $fromRecord = Versioned::get_all_versions(get_class($this->owner), $this->owner->ID)
+            ->find('Version', $from);
+        $toRecord = Versioned::get_all_versions(get_class($this->owner), $this->owner->ID)
+            ->find('Version', $to);
 
         $diff = new DataDifferencer($fromRecord, $toRecord);
         $changes = $diff->changedFieldNames();


### PR DESCRIPTION
`silverstripe/recipe-cms: "4.8.0"`
`silverstripe/asset-admin: "1.8.0"`

`Uncaught Exception Error: "__clone method called on non-object" at /var/www/mysite/www/vendor/silverstripe/versioned/src/DataDifferencer.php line 261 {"exception":"[object] (Error(code: 0): __clone method called on non-object at /var/www/mysite/www/vendor/silverstripe/versioned/src/DataDifferencer.php:261)"}`

This is caused by the humanizedChanges() function where the version grabbed didn't include the deleted/archived version.