### PR TITLE
v1.8: Add missing TypeCreator import to FolderTypeCreator

### DIFF
--- a/_legacy/GraphQL/FolderTypeCreator.php
+++ b/_legacy/GraphQL/FolderTypeCreator.php
@@ -11,6 +11,7 @@ use SilverStripe\Assets\Folder;
 use SilverStripe\ORM\Filterable;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\GraphQL\Pagination\Connection;
+use SilverStripe\GraphQL\TypeCreator;
 use SilverStripe\ORM\DataQuery;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DB;


### PR DESCRIPTION
The import is currently missing, which means the `class_exists()` check is always failing, and the class is never available.

![Screen Shot 2021-11-24 at 11 50 21 AM](https://user-images.githubusercontent.com/505788/143143192-fa5e9d08-ba38-4905-a1cf-55a237abf528.png)
