### PR TITLE
FIX Use regular string instead of heredoc so textcollector runs

### DIFF
--- a/code/Forms/ImageFormFactory.php
+++ b/code/Forms/ImageFormFactory.php
@@ -78,11 +78,10 @@ class ImageFormFactory extends FileFormFactory
                 ->setName('Dimensions')
         );
         if (Image::getLazyLoadingEnabled()) {
-            $titleTipContent = _t('SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.LoadingTitleTip', trim(<<<EOT
-Lazy loading can increase perceived page performance by slightly delaying media loading. Eager loading will load files
-as soon as possible and can be used if the image is in view as the page loads (above or near the fold).
-EOT
-            ));
+            $str = 'Lazy loading can increase perceived page performance by slightly delaying media loading. ' .
+            'Eager loading will load files as soon as possible and can be used if the image is in view as the page ' .
+            'loads (above or near the fold).';
+            $titleTipContent = _t('SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.LoadingTitleTip', $str);
             $field = DropdownField::create(
                 'Loading',
                 _t('SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.Loading', 'Loading'),


### PR DESCRIPTION
When running `vendor/bin/sake dev/tasks/i18nTextCollectorTask merge=1` the following exception was being triggered

`E_USER_NOTICE: Missing localisation default for key SilverStripe\AssetAdmin\Controller\AssetAdmin.LoadingTitleTip`

Converting the heredoc syntax to a regular string means text collector no longer throws the exception
