### PR TITLE
ENH Allow developers to decide if resampling is needed

### DIFF
--- a/code/Controller/AssetAdmin.php
+++ b/code/Controller/AssetAdmin.php
@@ -1207,7 +1207,7 @@ class AssetAdmin extends LeftAndMain implements PermissionProvider
     public function generateThumbnails(File $file, $thumbnailLinks = false)
     {
         $links = [];
-        if (!$file->getIsImage()) {
+        if (!$file->getIsImage() || $file->config()->resample_images === false) {
             return $links;
         }
         $generator = $this->getThumbnailGenerator();

--- a/code/Helper/ImageThumbnailHelper.php
+++ b/code/Helper/ImageThumbnailHelper.php
@@ -140,6 +140,10 @@ class ImageThumbnailHelper
     {
         $generated = [];
 
+        if ($file->config()->resample_images === false) {
+            return $generated;
+        }
+
         $store = Injector::inst()->get(AssetStore::class);
         $assetAdmin = AssetAdmin::singleton();
         $generator = $assetAdmin->getThumbnailGenerator();

--- a/code/Model/ThumbnailGenerator.php
+++ b/code/Model/ThumbnailGenerator.php
@@ -98,7 +98,7 @@ class ThumbnailGenerator
      */
     public function generateThumbnail(AssetContainer $file, $width, $height)
     {
-        if (!$file->getIsImage() || !$file->exists()) {
+        if (!$file->exists() || !$file->getIsImage() || $file->config()->resample_images === false) {
             return null;
         }
 
@@ -111,7 +111,7 @@ class ThumbnailGenerator
         $method = $this->config()->get('method');
         return $file->$method($width, $height);
     }
-    
+
     /**
      * Generate "src" property for this thumbnail.
      * This can be either a url or base64 encoded data


### PR DESCRIPTION
Sometimes, you just don't need the CMS to resample the images (e.g. when using S3 module + lambda resizing)