### PR TITLE
BUG Update asset-admin to use the correct allowed extension list for dropzone

### DIFF
--- a/code/Controller/AssetAdmin.php
+++ b/code/Controller/AssetAdmin.php
@@ -1316,7 +1316,7 @@ class AssetAdmin extends LeftAndMain implements PermissionProvider
         $upload = Upload::create();
         $upload->getValidator()->setAllowedExtensions(
             // filter out '' since this would be a regex problem on JS end
-            array_filter(File::config()->uninherited('allowed_extensions'))
+            array_filter(File::getAllowedExtensions())
         );
         $upload->getValidator()->setAllowedMaxFileSize(
             $this->config()->max_upload_size

--- a/tests/php/Controller/AssetAdminTest.php
+++ b/tests/php/Controller/AssetAdminTest.php
@@ -451,7 +451,6 @@ class AssetAdminTest extends FunctionalTest
 
             $config = $assetAdmin->getClientConfig();
             $acceptedFiles = $config['dropzoneOptions']['acceptedFiles'];
-            var_dump($acceptedFiles);
             $this->assertStringContainsString(
                 '.boom',
                 $acceptedFiles,

--- a/tests/php/Controller/AssetAdminTest.php
+++ b/tests/php/Controller/AssetAdminTest.php
@@ -16,6 +16,7 @@ use SilverStripe\Dev\FunctionalTest;
 use SilverStripe\Subsites\Extensions\FolderFormFactoryExtension;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\Security\SecurityToken;
+use SilverStripe\Core\Config\Config;
 
 /**
  * Tests {@see AssetAdmin}
@@ -440,5 +441,32 @@ class AssetAdminTest extends FunctionalTest
         ];
 
         $this->assertEquals($expected, $data);
+    }
+
+    public function testGetClientConfigExtensions()
+    {
+        Config::withConfig(function () {
+            $assetAdmin = AssetAdmin::singleton();
+            Config::modify()->set(File::class, 'allowed_extensions', ['boom']);
+
+            $config = $assetAdmin->getClientConfig();
+            $acceptedFiles = $config['dropzoneOptions']['acceptedFiles'];
+            var_dump($acceptedFiles);
+            $this->assertStringContainsString(
+                '.boom',
+                $acceptedFiles,
+                'Extension added to File::allowed_extensions should be allowed by asset admin'
+            );
+
+            Config::modify()->set(File::class, 'allowed_extensions', ['boom', 'boom' => false]);
+
+            $config = $assetAdmin->getClientConfig();
+            $acceptedFiles = $config['dropzoneOptions']['acceptedFiles'];
+            $this->assertStringNotContainsString(
+                '.boom',
+                $acceptedFiles,
+                'Extension that have been manually disallowed should be not be allowed by asset admin'
+            );
+        });
     }
 }


### PR DESCRIPTION
Asset-admin sends a list of allowed file extension to the front end for its drop zone settings. The problem is that this list is read directly from the `File::$allowed_extensions` rather than use the more robust `File::getAllowedExtension()`.

This means that if you use this kind of YML to [remove an extension from the allowed extension list](https://docs.silverstripe.org/en/4/developer_guides/files/allowed_file_types/#file-extensions-validation), the front end will still accept it:
```yml
SilverStripe\Assets\File:
  allowed_extensions:
    zip: false
```

The back end will still block the file, but you waste time uploading it and get a less useful error message.