### PR TITLE
FIX Remove preview panel from asset admin

### DIFF
--- a/code/Controller/AssetAdmin.php
+++ b/code/Controller/AssetAdmin.php
@@ -41,6 +41,7 @@ use SilverStripe\Security\Security;
 use SilverStripe\Security\SecurityToken;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\View\Requirements;
+use SilverStripe\View\SSViewer;
 
 /**
  * AssetAdmin is the 'file store' section of the CMS.
@@ -1432,5 +1433,16 @@ class AssetAdmin extends LeftAndMain implements PermissionProvider
 
         // Default permissions
         return parent::canView($member);
+    }
+
+    public function PreviewPanel()
+    {
+        $templates = SSViewer::get_templates_by_class(get_class($this), '_PreviewPanel', __CLASS__);
+        $template = SSViewer::chooseTemplate($templates);
+        // Only render preview panel if a template specifically for the asset admin has been provided
+        if ($template) {
+            return $this->renderWith($template);
+        }
+        return null;
     }
 }


### PR DESCRIPTION
A preview panel is provided to all `LeftAndMain` subclasses via silverstripe/silverstripe-admin#1252 - but it should not be provided for `AssetAdmin` by default.

This PR will not omit the preview panel by default (to fix a [broken behat test](https://app.travis-ci.com/github/silverstripe/silverstripe-asset-admin/jobs/568181799) which expects there not to be a preview panel here - but also because it just isn't needed here) - but allows developers to include it by adding a template for it in case there is some use case for it.

## Parent issue
- silverstripe/silverstripe-framework#10278