### PR TITLE
MNT Allow travis to pull the correct installer version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ import:
 
 env:
   global:
+    - REQUIRE_RECIPE="4.10.x-dev"
     - BEHAT_SUITE="asset-admin"


### PR DESCRIPTION
Travis is trying to pull installer 4.11 for tests of PRs on the `1.10` branch.
e.g. https://app.travis-ci.com/github/silverstripe/silverstripe-asset-admin/jobs/572953885

This change allows it to correctly use installer 4.10.x

**NOTE** this should be merged up immediately after merging, and the change _reverted_ during that merge (so that this change is not reflected in the `1` branch).