### PR TITLE
MNT Better detection of status-flags in behat

### DIFF
--- a/tests/behat/features/file-details.feature
+++ b/tests/behat/features/file-details.feature
@@ -24,8 +24,9 @@ Feature: File details
     When I click "Details" in the "#Editor .nav-tabs" element
     Then the rendered HTML should contain "<span class="editor__status-flag">Draft</span>"
     When I press the "Publish" button
-    Then I should not see a ".editor__status-flag" element
+    And I wait for 5 seconds
+    Then the rendered HTML should not contain "<span class="editor__status-flag">"
     And I fill in "Form_fileEditForm_Title" with "file-modified-1"
     And I press the "Save" button
+    And I wait for 5 seconds
     Then the rendered HTML should contain "<span class="editor__status-flag">Modified</span>"
-


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/37

Fix timing issue, also use same detection style as the rest of the test

https://github.com/silverstripe/silverstripe-graphql/runs/7460745250?check_suite_focus=true
` Then I should not see a ".editor__status-flag" element# SilverStripe\AssetAdmin\Tests\Behat\Context\FeatureContext::assertElementNotOnPage()
      An element matching css ".editor__status-flag" appears on this page, but it should not. (Behat\Mink\Exception\ExpectationException)`