### PR TITLE
ENH Don't call deprecated constructExtensions method

### DIFF
--- a/code/Forms/FileSearchFormFactory.php
+++ b/code/Forms/FileSearchFormFactory.php
@@ -21,11 +21,6 @@ class FileSearchFormFactory implements FormFactory
     use Extensible;
     use Injectable;
 
-    public function __construct()
-    {
-        $this->constructExtensions();
-    }
-
     /**
      * Generates the form
      *


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-versioned/runs/8065390818?check_suite_focus=true
> Uncaught Exception BadMethodCallException: "Object->__call(): the method 'constructExtensions' does not exist on 'SilverStripe\TestSession\TestSessionEnvironment'" at /home/runner/work/silverstripe-versioned/silverstripe-versioned/vendor/silverstripe/framework/src/Core/CustomMethods.php line 57 {"exception":"[object] (BadMethodCallException(code: 0): Object->__call(): the method 'constructExtensions' does not exist on 'SilverStripe\\TestSession\\TestSessionEnvironment' at /home/runner/work/silverstripe-versioned/silverstripe-versioned/vendor/silverstripe/framework/src/Core/CustomMethods.php:57)"}

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10350