### PR TITLE
graphQL: changed size attribute of File to Float

### DIFF
--- a/_graphql/types/File.yml
+++ b/_graphql/types/File.yml
@@ -17,7 +17,7 @@ File:
     name: String
     filename: String
     extension: String
-    size: Int
+    size: Float
     url: String
     thumbnail: String
     smallThumbnail: String


### PR DESCRIPTION
Resolves #889 

This bug needs to be addressed since its effect on the file admin is potentially devastating: In our case we migrated an SS3 installation to SS4 and they had files larger than the `2147483647` 32-bit integer size which basically rendered the whole file admin unusable.

As long there is no support for 64-bit integers, this could be feasible workaround.

An other approach would be to define a custom scalar type - is this supported by silverstripe's graphQL implementation?