### PR TITLE
FIX Cast absoluteUrl() argument to string

### DIFF
--- a/code/Controller/AssetAdminFile.php
+++ b/code/Controller/AssetAdminFile.php
@@ -40,7 +40,7 @@ class AssetAdminFile extends DataExtension
     {
         // Update edit link for this file to point to the new asset admin
         $controller = AssetAdmin::singleton();
-        $link = Director::absoluteURL($controller->getFileEditLink($this->owner));
+        $link = Director::absoluteURL((string) $controller->getFileEditLink($this->owner));
     }
 
     /**


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/642

Similar to https://github.com/silverstripe/silverstripe-elemental/pull/1029