### PR TITLE
MNT Broken builds

### DIFF
--- a/tests/php/GraphQL/FakeResolveInfo.php
+++ b/tests/php/GraphQL/FakeResolveInfo.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\AssetAdmin\Tests\GraphQL;
 
+use GraphQL\Language\AST\OperationDefinitionNode;
 use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\ObjectType;
@@ -12,20 +13,15 @@ class FakeResolveInfo extends ResolveInfo
 {
     public function __construct()
     {
-        // webonyx/graphql-php v0.12
-        if (!property_exists(__CLASS__, 'fieldDefinition')) {
-            return;
-        }
-        // webonyx/graphql-php v14
         parent::__construct(
-            FieldDefinition::create(['name' => 'fake', 'type' => Type::string()]),
-            [],
+            new FieldDefinition(['name' => 'fake', 'type' => Type::string()]),
+            new \ArrayObject(),
             new ObjectType(['name' => 'fake']),
             [],
             new Schema([]),
             [],
             '',
-            null,
+            new OperationDefinitionNode([]),
             []
         );
     }


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/659

Fixes `Error: Call to undefined method GraphQL\Type\Definition\FieldDefinition::create()`

Broken JS tests are unrelated