### PR TITLE
FEAT update CMS fields to allow user-specific permissions

### DIFF
--- a/code/Forms/AssetFormFactory.php
+++ b/code/Forms/AssetFormFactory.php
@@ -16,6 +16,7 @@ use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\FormFactory;
 use SilverStripe\Forms\HeaderField;
 use SilverStripe\Forms\HiddenField;
+use SilverStripe\Forms\ListboxField;
 use SilverStripe\Forms\OptionsetField;
 use SilverStripe\Forms\PopoverField;
 use SilverStripe\Forms\ReadonlyField;
@@ -25,6 +26,8 @@ use SilverStripe\Forms\TabSet;
 use SilverStripe\Forms\TextField;
 use SilverStripe\Forms\TreeDropdownField;
 use SilverStripe\Forms\TreeMultiselectField;
+use SilverStripe\Security\InheritedPermissions;
+use SilverStripe\Security\Member;
 
 abstract class AssetFormFactory implements FormFactory
 {
@@ -349,15 +352,17 @@ abstract class AssetFormFactory implements FormFactory
     {
         // Get permissions
         $viewersOptionsField = [
-            'Inherit' => _t(__CLASS__.'.INHERIT', 'Inherit from parent folder'),
-            'Anyone' => _t(__CLASS__.'.ANYONE', 'Anyone'),
-            'LoggedInUsers' => _t(__CLASS__.'.LOGGED_IN', 'Logged-in users'),
-            'OnlyTheseUsers' => _t(__CLASS__.'.ONLY_GROUPS', 'Only these groups (choose from list)')
+            InheritedPermissions::INHERIT => _t(__CLASS__.'.INHERIT', 'Inherit from parent folder'),
+            InheritedPermissions::ANYONE => _t(__CLASS__.'.ANYONE', 'Anyone'),
+            InheritedPermissions::LOGGED_IN_USERS => _t(__CLASS__.'.LOGGED_IN', 'Logged-in users'),
+            InheritedPermissions::ONLY_THESE_USERS => _t(__CLASS__.'.ONLY_GROUPS', 'Only these groups (choose from list)'),
+            InheritedPermissions::ONLY_THESE_MEMBERS => _t(__CLASS__.'.ONLY_MEMBERS', 'Only these users (choose from list)'),
         ];
 
         // No "Anyone" editors option
         $editorsOptionsField = $viewersOptionsField;
-        unset($editorsOptionsField['Anyone']);
+        unset($editorsOptionsField[InheritedPermissions::ANYONE]);
+        $membersMap = Member::get()->map('ID', 'Name');
 
         return Tab::create(
             'Permissions',
@@ -370,6 +375,11 @@ abstract class AssetFormFactory implements FormFactory
                 'ViewerGroups',
                 _t(__CLASS__.'.VIEWERGROUPS', 'Viewer Groups')
             ),
+            ListboxField::create(
+                'ViewerMembers',
+                _t(__CLASS__.'.VIEWERMEMBERS', 'Viewer Users'),
+                $membersMap
+            ),
             OptionsetField::create(
                 "CanEditType",
                 _t(__CLASS__.'.EDITHEADER', 'Who can edit this file?')
@@ -378,6 +388,11 @@ abstract class AssetFormFactory implements FormFactory
             TreeMultiselectField::create(
                 'EditorGroups',
                 _t(__CLASS__.'.EDITORGROUPS', 'Editor Groups')
+            ),
+            ListboxField::create(
+                'EditorMembers',
+                _t(__CLASS__.'.EDITORMEMBERS', 'Editor Users'),
+                $membersMap
             )
         );
     }

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^8.1",
-        "silverstripe/framework": "^5",
+        "silverstripe/framework": "^5.1",
         "silverstripe/admin": "^2",
         "silverstripe/graphql": "^5"
     },

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -64,15 +64,18 @@ en:
     ANYONE: Anyone
     EDITHEADER: 'Who can edit this file?'
     EDITORGROUPS: 'Editor Groups'
+    EDITORMEMBERS: 'Editor Users'
     FILENAME: Filename
     FOLDERLOCATION: Location
     INHERIT: 'Inherit from parent folder'
     LOGGED_IN: 'Logged-in users'
     ONLY_GROUPS: 'Only these groups (choose from list)'
+    ONLY_MEMBERS: 'Only these users (choose from list)'
     ROOTNAME: '(Top level)'
     SAVE: Save
     SAVED: Saved
     VIEWERGROUPS: 'Viewer Groups'
+    VIEWERMEMBERS: 'Viewer Users'
   SilverStripe\AssetAdmin\Forms\FileFormFactory:
     DOWNLOAD_FILE: 'Download file'
     INSERT_LINK: 'Link to file'


### PR DESCRIPTION
Companion to https://github.com/silverstripe/silverstripe-framework/pull/10819 and https://github.com/silverstripe/silverstripe-assets/pull/556

Adds CMS field to Asset admin to allow for user-specific permission management.


## Issue
- silverstripe/silverstripe-framework#10817 