### PR TITLE
FIX Insert file link text is required

### DIFF
--- a/code/Forms/FileFormFactory.php
+++ b/code/Forms/FileFormFactory.php
@@ -13,6 +13,7 @@ use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\HeaderField;
 use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\LiteralField;
+use SilverStripe\Forms\RequiredFields;
 use SilverStripe\Forms\Tab;
 use SilverStripe\Forms\TabSet;
 use SilverStripe\Forms\TextField;
@@ -498,5 +499,24 @@ class FileFormFactory extends AssetFormFactory
     public function getRequiredContext()
     {
         return parent::getRequiredContext() + ['RequireLinkText'];
+    }
+
+    /**
+     * Get the validator for the form to be built
+     *
+     * @param RequestHandler $controller
+     * @param $formName
+     * @param $context
+     * @return RequiredFields
+     */
+    protected function getValidator(RequestHandler $controller = null, $formName, $context = [])
+    {
+        $validator = parent::getValidator($controller, $formName, $context);
+
+        if (isset($context['RequireLinkText']) && $context['RequireLinkText']) {
+            $validator->addRequiredField('Text');
+        }
+
+        return $validator;
     }
 }

--- a/tests/behat/features/insert-an-image.feature
+++ b/tests/behat/features/insert-an-image.feature
@@ -155,6 +155,20 @@ Feature: Insert an image into a page
       And the "Description" field should contain "My file"
       And I should see "Link to file" in the "button[name=action_insert]" element
 
+  Scenario: I can link to a file with link text
+    Given I fill in the "Content" HTML field with "<p><img src='file1.jpg'></p>"
+    When I press the "Insert link" HTML field button
+      And I click "Link to a file" in the ".mce-menu" element
+      And I select the file named "folder1" in the gallery
+      And I click on the file named "file1" in the gallery
+    Then I should see the "Form_fileInsertForm" form
+      And I press the "Link to file" button
+    Then I should see "Link text is required"
+      And I fill in "Link text" with "My file"
+      And I press the "Link to file" button
+    Then the "Content" HTML field should contain "<a href="[file_link,id=2]">My file</a>"
+      And I press the "Save" button
+
   Scenario: I can wrap an image in a link to a file
     Given I fill in the "Content" HTML field with "<p><img src='file1.jpg'></p>"
     When I select the image "file1.jpg" in the "Content" HTML field


### PR DESCRIPTION
## Description
There is not proper validation for file link text, and it means that user can insert link to the file as empty string without any content.

## Parent issue
- https://github.com/silverstripe/silverstripe-asset-admin/issues/1401