### PR TITLE
ENH Let AssetAdmin default to Upload_Validator default upload limits

### DIFF
--- a/code/Controller/AssetAdmin.php
+++ b/code/Controller/AssetAdmin.php
@@ -1280,9 +1280,10 @@ class AssetAdmin extends LeftAndMain implements PermissionProvider
             // filter out '' since this would be a regex problem on JS end
             array_filter(File::getAllowedExtensions() ?? [])
         );
-        $upload->getValidator()->setAllowedMaxFileSize(
-            $this->config()->max_upload_size
-        );
+        $maxFileSize = $this->config()->get('max_upload_size');
+        if ($maxFileSize !== null) {
+            $upload->getValidator()->setAllowedMaxFileSize($maxFileSize);
+        }
 
         return $upload;
     }


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
This change is based on https://github.com/silverstripe/silverstripe-assets/pull/469#pullrequestreview-749727900 and aims to get the other work in a state it can be merged in

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->
Set this configuration - it should be respected by asset admin when before it was not.
```yml
SilverStripe\Assets\Upload_Validator:
  default_max_file_size:
    '[image]': '500k'
    '*' : '1m'
```

Then set this configuration - the `Upload_Validator` configuration should still work in `UploadField` in forms but not in asset admin - asset admin should now allow up to 2MB uploads for all file types.
```yml
SilverStripe\AssetAdmin\Controller\AssetAdmin:
  max_upload_size: 2m
```

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-framework/issues/10058

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
