### PR TITLE
TLN: change en.js word for "Details" to be "Edit"

### DIFF
--- a/client/lang/en.js
+++ b/client/lang/en.js
@@ -6,6 +6,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
   }
 } else {
   ss.i18n.addDictionary('en', {
+    'AssetAdmin.DETAILS': 'Edit',
     "AssetAdmin.ADD_FILES": "Add from files",
     "AssetAdmin.ADD_FOLDER_BUTTON": "Add folder",
     "AssetAdmin.BACK": "Back",


### PR DESCRIPTION
Right now you see this when you select an image:

![image](https://github.com/silverstripe/silverstripe-asset-admin/assets/167154/7a5968ac-eec6-430f-b141-fbb5b3d18bf1)

That does not make much sense, because you can already see the details and the button really is there to "EDIT" the image, as you can already see the details and because when you edit, you always edit "details"

![image](https://github.com/silverstripe/silverstripe-asset-admin/assets/167154/d180c750-c41f-4573-a77c-42946538304d)

For this purpose, I have added the english "phrase" for details now to be "edit". 