### PR TITLE
ENH Improve quality of thumbnails in assetadmin and uploadfield

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -18,6 +18,7 @@ SilverStripe\Core\Injector\Injector:
     class: SilverStripe\AssetAdmin\Model\ThumbnailGenerator
     properties:
       Generates: true
+      thumbnailMethod: 'Fill'
   SilverStripe\AssetAdmin\Controller\AssetAdmin:
     properties:
       ThumbnailGenerator: '%$SilverStripe\AssetAdmin\Model\ThumbnailGenerator.assetadmin'
@@ -53,3 +54,4 @@ SilverStripe\Core\Injector\Injector:
     class: SilverStripe\AssetAdmin\Model\ThumbnailGenerator
     properties:
       Generates: false
+      thumbnailMethod: 'Fill'

--- a/code/Forms/UploadField.php
+++ b/code/Forms/UploadField.php
@@ -42,13 +42,13 @@ class UploadField extends FormField implements FileHandleField
      * @config
      * @var int
      */
-    private static $thumbnail_width = 60;
+    private static $thumbnail_width = 120;
 
     /**
      * @config
      * @var int
      */
-    private static $thumbnail_height = 60;
+    private static $thumbnail_height = 120;
 
     /**
      * Set if uploading new files is enabled.

--- a/code/GraphQL/Resolvers/FolderTypeResolver.php
+++ b/code/GraphQL/Resolvers/FolderTypeResolver.php
@@ -18,10 +18,20 @@ use SilverStripe\Versioned\Versioned;
 use InvalidArgumentException;
 use Exception;
 use Closure;
+use SilverStripe\AssetAdmin\Controller\AssetAdmin;
 use SilverStripe\ORM\DataQuery;
 
 class FolderTypeResolver
 {
+    /**
+     * Any IDs of files which we're allowed to generate thumbnails for.
+     * The intention is to (as much as is feasible) only allow generating thumbnails
+     * during asset admin graphQL requests and not for requests that could be performed
+     * by an attacker.
+     * @internal
+     */
+    private static array $idsAllowedToGenerateThumbnails = [];
+
     /**
      * @param Folder $object
      * @param array $args
@@ -72,6 +82,17 @@ class FolderTypeResolver
         // IDs we need.
         $canViewList = $list->filter('ID', $canViewIDs ?: 0)
             ->limit(null);
+
+        // If we haven't already marked IDs as being okay to generate thumbnails,
+        // and we have a safe limit for the number of children,
+        // mark these children as being okay to generate thumbnails for.
+        if (empty(self::$idsAllowedToGenerateThumbnails)
+            && !empty($args['limit'])
+            && is_numeric($args['limit'])
+            && (int)$args['limit'] <= AssetAdmin::config()->get('page_length')
+        ) {
+            self::$idsAllowedToGenerateThumbnails = $canViewIDs;
+        }
 
         return $canViewList;
     }
@@ -180,5 +201,10 @@ class FolderTypeResolver
             });
             return $list;
         };
+    }
+
+    public static function getIdsAllowedToGenerateThumbnails(): array
+    {
+        return self::$idsAllowedToGenerateThumbnails;
     }
 }

--- a/code/Model/ThumbnailGenerator.php
+++ b/code/Model/ThumbnailGenerator.php
@@ -60,10 +60,15 @@ class ThumbnailGenerator
     ];
 
     /**
-     * @var string
-     * @config
+     * @var string The default method to use for generating thumbnails if a specific method hasn't been
+     * set for a given generator instance.
      */
     private static $method = 'FitMax';
+
+    /**
+     * The method that this generator instance will use to generate thumbnails.
+     */
+    private string $thumbnailMethod = '';
 
     /**
      * Generate thumbnail and return the "src" property for this thumbnail
@@ -108,7 +113,7 @@ class ThumbnailGenerator
         }
 
         // Make large thumbnail
-        $method = $this->config()->get('method');
+        $method = $this->getThumbnailMethod();
         return $file->$method($width, $height);
     }
 
@@ -171,6 +176,27 @@ class ThumbnailGenerator
     public function setGenerates($generates)
     {
         $this->generates = $generates;
+        return $this;
+    }
+
+    /**
+     * Get the method which will be used to generate thumbnails.
+     */
+    public function getThumbnailMethod(): string
+    {
+        if ($this->thumbnailMethod) {
+            return $this->thumbnailMethod;
+        }
+        return static::config()->get('method');
+    }
+
+    /**
+     * Set the method which will be used to generate thumbnails.
+     * Pass an empty string to reset to the default method.
+     */
+    public function setThumbnailMethod(string $method): static
+    {
+        $this->thumbnailMethod = $method;
         return $this;
     }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
- Improves the quality of thumbnails in the tile view of `AssetAdmin` and in `UploadField` instances.
- Makes the grid view of `AssetAdmin` use the same thumbnails as the tile view.
- Updates the thumbnail in `AssetAdmin` if the thumbnail method has changed since the thumbnail was last generated.

See https://github.com/silverstripe/silverstripe-asset-admin/pull/1224 for more details - there was a lot of discussion in there.

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->
Before pulling this PR, add a bunch of different images to asset admin, and into upload fields.
Then pull this PR.
Check asset admin (both tile and gallery view) - you should see the new thumbnails.
Check uploadfield - you should see the new thumbnails there too.

If the thumbnails were blurry before the PR, you should notice a stark improvement after pulling the PR.

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-asset-admin/issues/1228

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
