### PR TITLE
FIX Use canDelete, not the now-deleted canArchive

### DIFF
--- a/code/Controller/AssetAdmin.php
+++ b/code/Controller/AssetAdmin.php
@@ -28,7 +28,6 @@ use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Injector\Injector;
-use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\FormFactory;
 use SilverStripe\ORM\ArrayList;
@@ -1082,9 +1081,7 @@ class AssetAdmin extends LeftAndMain implements PermissionProvider
         $object['filename'] = $file->Filename;
         $object['url'] = $file->AbsoluteURL;
         $object['canEdit'] = $file->canEdit();
-        $object['canDelete'] = ($file->hasMethod('canArchive'))
-            ? Deprecation::withNoReplacement(fn() => $file->canArchive())
-            : $file->canDelete();
+        $object['canDelete'] = $file->canDelete();
 
         $owner = $file->Owner();
 

--- a/code/GraphQL/Resolvers/AssetAdminResolver.php
+++ b/code/GraphQL/Resolvers/AssetAdminResolver.php
@@ -16,7 +16,6 @@ use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\Filterable;
 use SilverStripe\Versioned\Versioned;
 use InvalidArgumentException;
-use SilverStripe\Dev\Deprecation;
 
 class AssetAdminResolver
 {
@@ -127,8 +126,7 @@ class AssetAdminResolver
         $deletedIDs = [];
         $member = UserContextProvider::get($context);
         foreach ($files as $file) {
-            $canArchive = Deprecation::withNoReplacement(fn() => $file->canArchive($member));
-            if ($canArchive) {
+            if ($file->canDelete($member)) {
                 $file->doArchive();
                 $deletedIDs[] = $file->ID;
             }

--- a/tests/php/Controller/AssetAdminTest/FileExtension.php
+++ b/tests/php/Controller/AssetAdminTest/FileExtension.php
@@ -28,14 +28,6 @@ class FileExtension extends DataExtension implements TestOnly
         }
     }
 
-    public function canArchive($member = null)
-    {
-        if ($this->owner->Name === 'disallowCanDelete.txt') {
-            return false;
-        }
-        return $this->owner->canDelete($member);
-    }
-
 
     public function canCreate($member = null, $context = [])
     {


### PR DESCRIPTION
`canArchive()` is removed in favour of `canDelete()` in https://github.com/silverstripe/silverstripe-versioned/pull/460

## Issue
- https://github.com/silverstripe/silverstripe-versioned/issues/447