### PR TITLE
ENH Don't emit deprecation warnings for unavoidable API calls

### DIFF
--- a/code/Controller/AssetAdmin.php
+++ b/code/Controller/AssetAdmin.php
@@ -28,6 +28,7 @@ use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\FormFactory;
 use SilverStripe\ORM\ArrayList;
@@ -1081,7 +1082,9 @@ class AssetAdmin extends LeftAndMain implements PermissionProvider
         $object['filename'] = $file->Filename;
         $object['url'] = $file->AbsoluteURL;
         $object['canEdit'] = $file->canEdit();
-        $object['canDelete'] = ($file->hasMethod('canArchive')) ? $file->canArchive() : $file->canDelete();
+        $object['canDelete'] = ($file->hasMethod('canArchive'))
+            ? Deprecation::withNoReplacement(fn() => $file->canArchive())
+            : $file->canDelete();
 
         $owner = $file->Owner();
 

--- a/code/GraphQL/Resolvers/AssetAdminResolver.php
+++ b/code/GraphQL/Resolvers/AssetAdminResolver.php
@@ -16,6 +16,7 @@ use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\Filterable;
 use SilverStripe\Versioned\Versioned;
 use InvalidArgumentException;
+use SilverStripe\Dev\Deprecation;
 
 class AssetAdminResolver
 {
@@ -126,7 +127,8 @@ class AssetAdminResolver
         $deletedIDs = [];
         $member = UserContextProvider::get($context);
         foreach ($files as $file) {
-            if ($file->canArchive($member)) {
+            $canArchive = Deprecation::withNoReplacement(fn() => $file->canArchive($member));
+            if ($canArchive) {
                 $file->doArchive();
                 $deletedIDs[] = $file->ID;
             }


### PR DESCRIPTION
`Versioned::canArchive()` is deprecated in https://github.com/silverstripe/silverstripe-versioned/pull/461

We can't stop calling it directly until CMS 6 because people may have implemented extensions that update the result of this permission check.

## Issue
- https://github.com/silverstripe/silverstripe-versioned/issues/447