### PR TITLE
MNT Fix behat test

### DIFF
--- a/tests/behat/features/manage-files.feature
+++ b/tests/behat/features/manage-files.feature
@@ -281,6 +281,7 @@ Feature: Manage files
       Then I should see "No items found"
       And I should see "File type: Archive"
     Then I press the "Close" button
+      And I wait for 1 second
       And I should not see an "#AssetSearchForm_searchbox" element
       And I should see the file named "folder1" in the gallery
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/349

Fixes https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/12342589564/job/34442717488#step:12:777

    And I should see the file named "folder1" in the gallery     # SilverStripe\AssetAdmin\Tests\Behat\Context\FixtureContext::iShouldSeeTheGalleryItem()
      File named folder1 could not be found