### PR TITLE
ENH Remove unnecessary calls to setUseSearchContext()

### DIFF
--- a/code/Forms/AssetFormFactory.php
+++ b/code/Forms/AssetFormFactory.php
@@ -395,8 +395,7 @@ abstract class AssetFormFactory implements FormFactory
                 _t(__CLASS__ . '.VIEWERMEMBERS', 'Viewer Users'),
                 Member::get()
             )
-                ->setIsLazyLoaded(true)
-                ->setUseSearchContext(true),
+                ->setIsLazyLoaded(true),
             OptionsetField::create(
                 "CanEditType",
                 _t(__CLASS__ . '.EDITHEADER', 'Who can edit this file?')
@@ -412,7 +411,6 @@ abstract class AssetFormFactory implements FormFactory
                 Member::get()
             )
                 ->setIsLazyLoaded(true)
-                ->setUseSearchContext(true)
         );
 
         return $tab;


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11647

I'm removing these calls in CMS 6 rather than CMS 5 because the original PR targets CMS 5.3, and we'd need to add in a composer conflict to ensure the version of framework we're using is the latest patch, and the remove those conflicts in CMS 6.

I think it's cleaner to just target CMS 6 and leave the redundant though harmless calls in CMS 5