### PR TITLE
ENH Prepopulate version number cache

### DIFF
--- a/code/Controller/AssetAdminOpen.php
+++ b/code/Controller/AssetAdminOpen.php
@@ -165,6 +165,10 @@ class AssetAdminOpen extends LeftAndMain
                 $query->sort('"IsFolderTmp" DESC', null, true);
             });
             $childFiles = $childFiles->limit($limit, $offset);
+            // Prepopulate the Versioned cache used by Versioned::canViewVersioned() which is called
+            // as part of the looped $childFile->canView() check below
+            // This will save a large number of individual DB queries
+            $childFiles->prepopulateCaches();
             foreach ($childFiles as $childFile) {
                 if (!$childFile->canView()) {
                     continue;

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^8.3",
-        "silverstripe/framework": "^6",
+        "silverstripe/framework": "^6.1",
         "silverstripe/admin": "^3"
     },
     "require-dev": {


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11703

Requires https://github.com/silverstripe/silverstripe-versioned/pull/500

When viewing files in asset admin there are a large number of DB queries triggered by `$file->canView()` which called `Versioned->canViewVersioned()`. For every file in the paginated view, you will get 2 queries:

`SELECT "Version" FROM "File" WHERE "ID" = ?`
`SELECT "Version" FROM "File_Live" WHERE "ID" = ?`

This PR optimises the down to a pair of large queries whose results are cached in memory:

`SELECT "ID", "Version" FROM "File" WHERE "ID" IN (?, ?, ?, ?, ?, ?, ?, ?)`
`SELECT "ID", "Version" FROM "File_Live" WHERE "ID" IN (?, ?, ?, ?, ?, ?, ?, ?)`
