### PR TITLE
MNT Fix behat test

### DIFF
--- a/tests/behat/features/multi-file-upload-field.feature
+++ b/tests/behat/features/multi-file-upload-field.feature
@@ -4,7 +4,7 @@ Feature: Multi file Upload field
   I want to interact with the upload field to select files
 
   Background:
-    Given I add an extension "SilverStripe\FrameworkTest\Extension\CompanyGroupPhotoJpgOnlyExtension" to the "SilverStripe\FrameworkTest\Model\Company" class
+    Given I add an extension "SilverStripe\FrameworkTest\Extension\CompanyGroupPhotoJpgOnlyExtension" to the "SilverStripe\FrameworkTest\Model\Company" class without dev-build
     Given a "page" "About Us" has the "Content" "<p>My awesome content</p>"
       And a "image" "folder1/file1.jpg"
       And a "image" "folder1/file2.jpg"


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/411

dev/build calls requireDefaultRecords() which means the ACME record creates in this feature file won't be visible

Not an issue in CMS 5.4 as dev/build wasn't being created - i.e. there was only 1 record in the model admin