### PR TITLE
FIX Correctly filter by category

### DIFF
--- a/code/Controller/AssetAdminOpen.php
+++ b/code/Controller/AssetAdminOpen.php
@@ -411,9 +411,20 @@ class AssetAdminOpen extends LeftAndMain
             $list = $list->filter("Created:LessThanOrEqual", $toDate->dataValue().' 23:59:59');
             $search = true;
         }
-        // Categories (mapped to extensions through the enum type automatically)
+        // Categories (mapped to extensions)
         if (!empty($filter['appCategory'])) {
-            $list = $list->filter('Name:EndsWith', $filter['appCategory']);
+            $category = $filter['appCategory'];
+            $categoryValues = File::config()->get('app_categories');
+            // Sanitise category names (some contain slashes) and make all upper case
+            foreach ($categoryValues as $key => $extensions) {
+                unset($categoryValues[$key]);
+                $newKey = strtoupper(preg_replace('/[^a-zA-Z0-9]/', '', $key));
+                $categoryValues[$newKey] = $extensions;
+            }
+            if (!isset($categoryValues[$category])) {
+                $this->jsonError(404);
+            }
+            $list = $list->filter('Name:EndsWith', $categoryValues[$category]);
             $search = true;
         }
         // Filter unknown id by known child if search is not applied

--- a/tests/behat/features/change-sort-order.feature
+++ b/tests/behat/features/change-sort-order.feature
@@ -62,7 +62,7 @@ Feature: Change view for asset admin
       And I am logged in as a member of "EDITOR" group
       And I go to "/admin/assets"
 
-  Scenario: I can switch the sorting order in table view
+  Scenario: I can switch the sorting order in gallery view
     When I click on the file named "folder1" in the gallery
       And I click on the ".gallery__sort a" element
       And I wait until I see the ".gallery__sort .chosen-results" element

--- a/tests/behat/features/filter-types.feature
+++ b/tests/behat/features/filter-types.feature
@@ -1,0 +1,120 @@
+@assets @retry @job1
+Feature: Filter in asset admin
+  As a cms author
+  I want to filter files in various ways
+
+  Background:
+    Given a "file" "file001" has "Filename"="folder1/document.pdf" and "Title"="file001"
+      And a "image" "file002" has "Filename"="folder1/file1.jpg" and "Title"="file002"
+      And a "image" "file003" has "Filename"="folder1/file2.jpg" and "Title"="file003"
+      # Adding multiple versions of folder/testfile.jpg is intentional
+      # We do this to avoid having to provide so many files in tests/behat/files/
+      And a "image" "file004" has "Filename"="folder1/testfile.jpg" and "Title"="file004"
+      And a "image" "file005" has "Filename"="folder1/testfile.jpg" and "Title"="file005"
+      And a "image" "file006" has "Filename"="folder1/testfile.jpg" and "Title"="file006"
+      And a "image" "file007" has "Filename"="folder1/testfile.jpg" and "Title"="file007"
+      And a "image" "file008" has "Filename"="folder1/testfile.jpg" and "Title"="file008"
+      And a "image" "file009" has "Filename"="folder1/testfile.jpg" and "Title"="file009"
+      And a "image" "file010" has "Filename"="folder1/testfile.jpg" and "Title"="file010"
+      And a "image" "file011" has "Filename"="folder1/testfile.jpg" and "Title"="file011"
+      And a "image" "file012" has "Filename"="folder1/testfile.jpg" and "Title"="file012"
+      And a "image" "file013" has "Filename"="folder1/testfile.jpg" and "Title"="file013"
+      And a "image" "file014" has "Filename"="folder1/testfile.jpg" and "Title"="file014"
+      And a "image" "file015" has "Filename"="folder1/testfile.jpg" and "Title"="file015"
+      And a "image" "file016" has "Filename"="folder1/testfile.jpg" and "Title"="file016"
+      And a "image" "file017" has "Filename"="folder1/testfile.jpg" and "Title"="file017"
+      And a "image" "file018" has "Filename"="folder1/testfile.jpg" and "Title"="file018"
+      And a "image" "file019" has "Filename"="folder1/testfile.jpg" and "Title"="file019"
+      And a "image" "file020" has "Filename"="folder1/testfile.jpg" and "Title"="file020"
+      And a "image" "file021" has "Filename"="folder1/testfile.jpg" and "Title"="file021"
+      # subfolder names must start with a letter greater than "t"
+      And a "image" "file01" has "Filename"="folder1/xsubfolder1/file1.jpg" and "Title"="file01"
+      And a "image" "file02" has "Filename"="folder1/zsubfolder2/file2.jpg" and "Title"="file02"
+      And the "group" "EDITOR" has permissions "Access to 'Files' section" and "FILE_EDIT_ALL"
+      And I am logged in as a member of "EDITOR" group
+      And I go to "/admin/assets"
+
+  Scenario: I can filter by name in gallery view
+    When I click on the file named "folder1" in the gallery
+      And I click on the file named "xsubfolder1" in the gallery
+      And I press the "Show search" button
+      And I fill in "SearchBox__name" with "file01"
+      And I press the "Enter" key in the "SearchBox__name" field
+    Then I should see the file named "file010" in the gallery
+      And I should see the file named "file019" in the gallery
+      And I should see the file named "file01" in the gallery
+      And I should not see the file named "file021" in the gallery
+      And I should not see the file named "file001" in the gallery
+      And I should not see the file named "file02" in the gallery
+    When I press the "Close" button
+      And I click on the file named "folder1" in the gallery
+      And I click on the file named "xsubfolder1" in the gallery
+      And I press the "Show search" button
+      And I press the "Advanced" button
+      And I check "Limit to current folder and its sub-folders?"
+      And I press the "Search" button
+    Then I should not see the file named "file001" in the gallery
+      And I should not see the file named "file010" in the gallery
+      And I should not see the file named "file02" in the gallery
+
+  Scenario: I can filter by name in list view
+    Given I press the "table" button
+      And I wait until I see the ".gallery__table-row" element
+    When I click on the file named "folder1" in the gallery
+      And I click on the file named "xsubfolder1" in the gallery
+      And I press the "Show search" button
+      And I fill in "SearchBox__name" with "file01"
+      And I press the "Enter" key in the "SearchBox__name" field
+    Then I should see the file named "file010" in the gallery
+      And I should see the file named "file019" in the gallery
+      And I should see the file named "file01" in the gallery
+      And I should not see the file named "file021" in the gallery
+      And I should not see the file named "file001" in the gallery
+      And I should not see the file named "file02" in the gallery
+    When I press the "Close" button
+      And I click on the file named "folder1" in the gallery
+      And I click on the file named "xsubfolder1" in the gallery
+      And I press the "Show search" button
+      And I press the "Advanced" button
+      And I check "Limit to current folder and its sub-folders?"
+      And I press the "Search" button
+    Then I should not see the file named "file001" in the gallery
+      And I should not see the file named "file010" in the gallery
+      And I should not see the file named "file02" in the gallery
+
+  Scenario: I can filter by category in gallery view
+    When I click on the file named "folder1" in the gallery
+      And I press the "Show search" button
+      And I press the "Advanced" button
+      And I select "Image" in the "File type" dropdown
+      And I press the "Search" button
+    Then I should see the file named "file002" in the gallery
+      And I should see the file named "file021" in the gallery
+      And I should see the file named "file01" in the gallery
+      And I should not see the file named "file001" in the gallery
+    When I press the "Advanced" button
+      And I select "Document" in the "File type" dropdown
+      And I press the "Search" button
+    Then I should see the file named "file001" in the gallery
+      And I should not see the file named "file002" in the gallery
+      And I should not see the file named "file021" in the gallery
+      And I should not see the file named "file01" in the gallery
+
+  Scenario: I can filter by category in list view
+    Given I press the "table" button
+    When I click on the file named "folder1" in the gallery
+      And I press the "Show search" button
+      And I press the "Advanced" button
+      And I select "Image" in the "File type" dropdown
+      And I press the "Search" button
+    Then I should see the file named "file002" in the gallery
+      And I should see the file named "file021" in the gallery
+      And I should see the file named "file01" in the gallery
+      And I should not see the file named "file001" in the gallery
+    When I press the "Advanced" button
+      And I select "Document" in the "File type" dropdown
+      And I press the "Search" button
+    Then I should see the file named "file001" in the gallery
+      And I should not see the file named "file002" in the gallery
+      And I should not see the file named "file021" in the gallery
+      And I should not see the file named "file01" in the gallery

--- a/tests/php/Controller/AssetAdminOpenTest.php
+++ b/tests/php/Controller/AssetAdminOpenTest.php
@@ -112,6 +112,14 @@ class AssetAdminOpenTest extends FunctionalTest
                 'pageLength' => 0,
                 'expectedCode' => 404,
             ],
+            'Reject invalid category' => [
+                'idType' => 'existing',
+                'fail' => '',
+                'filter' => 'filter[appCategory]=BANANA',
+                'page' => 0,
+                'pageLength' => 0,
+                'expectedCode' => 404,
+            ],
             'Reject fail canView()' => [
                 'idType' => 'existing',
                 'fail' => 'can-view',


### PR DESCRIPTION
The original code for this seems to have been pulled from [`FileFilter::filterList()`](https://github.com/silverstripe/silverstripe-asset-admin/blob/12aba732ff17aa37fb9ee612a3526319c1ca5315/code/GraphQL/FileFilter.php#L103-L107) - but the enum that comment references is a GraphQL enum which is created in [`Builder::updateSchema()`](https://github.com/silverstripe/silverstripe-asset-admin/blob/12aba732ff17aa37fb9ee612a3526319c1ca5315/code/GraphQL/Schema/Builder.php#L31-L42).

So in CMS 6 before this PR we're just doing a filter like `->filter('Name:EndsWith', 'IMAGE')` (we haven't mapped to the extensions yet).

Requires https://github.com/silverstripe/silverstripe-behat-extension/pull/305 to be merged for new CI to go green

## Issue

- https://github.com/silverstripe/silverstripe-asset-admin/issues/1576