### PR TITLE
ENH Use new DataList caching

### DIFF
--- a/code/Controller/AssetAdmin.php
+++ b/code/Controller/AssetAdmin.php
@@ -1218,7 +1218,7 @@ class AssetAdmin extends AssetAdminOpen implements PermissionProvider
         }
 
         $id = (int) $data['ID'];
-        $record = DataObject::get_by_id(File::class, $id);
+        $record = DataObject::get(File::class)->setUseCache(true)->byID($id);
 
         if (!$record) {
             $this->jsonError(404);
@@ -1271,7 +1271,7 @@ class AssetAdmin extends AssetAdminOpen implements PermissionProvider
         }
 
         $id = (int) $data['ID'];
-        $record = DataObject::get_by_id(File::class, $id);
+        $record = DataObject::get(File::class)->setUseCache(true)->byID($id);
 
         if (!$record) {
             $this->jsonError(404);

--- a/code/Forms/PreviewImageField.php
+++ b/code/Forms/PreviewImageField.php
@@ -73,7 +73,7 @@ class PreviewImageField extends FormField
     public function getRecord()
     {
         if ($this->recordID) {
-            return DataObject::get_by_id(File::class, $this->recordID);
+            return DataObject::get(File::class)->setUseCache(true)->byID($this->recordID);
         }
         return null;
     }


### PR DESCRIPTION
Replaces deprecated `DataObject::get_one()` and `DataObject::get_by_id()` in favour of the new DataList query caching.

> [!IMPORTANT]
> Relies on https://github.com/silverstripe/silverstripe-framework/pull/11768
> DO NOT MERGE until that PR has been merged in

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11767
