### PR TITLE
ENH Optimise SQL queries to improve performance

### DIFF
--- a/code/Controller/AssetAdminOpen.php
+++ b/code/Controller/AssetAdminOpen.php
@@ -433,8 +433,8 @@ class AssetAdminOpen extends LeftAndMain
         }
         // Filter unknown id by known child if search is not applied
         if (!$search && isset($filter['anyChildId'])) {
-            $child = File::get()->byID($filter['anyChildId']);
-            $id = $child ? ($child->ParentID ?: 0) : 0;
+            $parentIDs = File::get()->filter('ID', $filter['anyChildId'])->limit(1)->column('ParentID');
+            $id = empty($parentIDs) ? 0 : $parentIDs[0];
             if ($id) {
                 $list = $list->filter('ID', $id);
             } else {


### PR DESCRIPTION
While not reducing the _number_ of queries, it's more efficient to get the specific column we need data for rather than hydrating the whole record.

## Issue

- https://github.com/silverstripe/.github/issues/416