### PR TITLE
ENH Disable sorting on queries where sort order doesn't matter

### DIFF
--- a/code/Controller/AssetAdmin.php
+++ b/code/Controller/AssetAdmin.php
@@ -720,10 +720,12 @@ class AssetAdmin extends AssetAdminOpen implements PermissionProvider
 
     /**
      * Retrieves a list of files by their IDs
+     * Does not respect default sort order
      */
     private function getFilesByIDs(array $ids, bool $includeFolders, int $missingFileErrorCode): ArrayList
     {
-        $files = File::get()->filter(['ID' => $ids]);
+        // Disabling sort improves performance
+        $files = File::get()->sort(null)->filter(['ID' => $ids]);
         if ($files->count() !== count($ids)) {
             $this->jsonError($missingFileErrorCode);
         }

--- a/code/Controller/AssetAdminFile.php
+++ b/code/Controller/AssetAdminFile.php
@@ -215,6 +215,7 @@ class AssetAdminFile extends Extension
 
     /**
      * Recursively get the $ids of nested Files and Folders, including the original parent Folder
+     * Does not respect sort order
      *
      * @param array $ids
      * @param int $maxDepth Hard limit of max depth
@@ -225,7 +226,8 @@ class AssetAdminFile extends Extension
         if ($maxDepth === 0) {
             return $ids;
         }
-        $childIDs = File::get()->filter('ParentID', $ids)->column('ID');
+        // Disabling sort improves performance
+        $childIDs = File::get()->filter('ParentID', $ids)->sort(null)->column('ID');
         if (empty($childIDs)) {
             return $ids;
         }


### PR DESCRIPTION
Sorting queries can be slow, especially on large datasets and especially if indexes aren't optimised. We should avoid sorting when the sort order doesn't matter.


## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11833