### PR TITLE
MNT Update unit tests for PHP 8.5

### DIFF
--- a/tests/php/Forms/UploadFieldTest.php
+++ b/tests/php/Forms/UploadFieldTest.php
@@ -69,7 +69,6 @@ class UploadFieldTest extends SapphireTest
         AssetAdmin::config()->set('max_upload_size', $adminMaxFileSize);
         $admin = new AssetAdmin();
         $reflectionGetUpload = new ReflectionMethod($admin, 'getUpload');
-        $reflectionGetUpload->setAccessible(true);
         /** @var Upload $upload */
         $upload = $reflectionGetUpload->invoke($admin);
         $this->assertSame($expected, $upload->getValidator()->getAllowedMaxFileSize());


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/455

The following changes were made based on the [PHP 8.5 changelog](https://www.php.net/ChangeLog-8.php):

- The setAccessible() methods of various Reflection objects have been deprecated, as those no longer have an effect.