### PR TITLE
DOC Correct typos  with codespell in comments and test files

### DIFF
--- a/code/Controller/AssetAdmin.php
+++ b/code/Controller/AssetAdmin.php
@@ -589,7 +589,7 @@ class AssetAdmin extends AssetAdminOpen implements PermissionProvider
         }
         $folder = $file->ParentID ? $file->Parent()->getFilename() : '/';
 
-        // If extension is the same, attempt to re-use existing name
+        // If extension is the same, attempt to reuse existing name
         if (File::get_file_extension($tmpFile['name']) === File::get_file_extension($data['Name'])) {
             $tmpFile['name'] = $data['Name'];
         } else {

--- a/code/Forms/UploadField.php
+++ b/code/Forms/UploadField.php
@@ -120,7 +120,7 @@ class UploadField extends FormField implements FileHandleField
             'payloadFormat' => 'urlencoded',
         ];
 
-        // use array_values to ensure 0-based so does not get coverted to a JS object
+        // use array_values to ensure 0-based so does not get converted to a JS object
         $defaults['data']['maxFilesize'] = $this->getAllowedMaxFileSize() / 1024 / 1024;
         $defaults['data']['maxFiles'] = $this->getAllowedMaxFileNumber();
         $defaults['data']['maxParallelUploads'] = $this->getMaxParallelUploads();

--- a/tests/behat/features/multi-file-upload-field.feature
+++ b/tests/behat/features/multi-file-upload-field.feature
@@ -68,7 +68,7 @@ Feature: Multi file Upload field
     # Required to avoid "unsaved changed" browser dialog
     Then I press the "Save" button
 
-  Scenario: I can select mulitple files and invalid extension validation works
+  Scenario: I can select multiple files and invalid extension validation works
     When I click "Choose existing" in the ".uploadfield" element
     And I press the "Back" HTML field button
     And I select the file named "folder1" in the gallery

--- a/tests/php/Controller/AssetAdminTest.php
+++ b/tests/php/Controller/AssetAdminTest.php
@@ -323,7 +323,7 @@ class AssetAdminTest extends FunctionalTest
 
         $data = $assetAdmin->getMinimalistObjectFromData($file);
 
-        // Thumbnail value is hard to predit, so we'll just check that it's there before unseting it.
+        // Thumbnail value is hard to predict, so we'll just check that it's there before unsetting it.
         $this->assertNotEmpty($data['thumbnail']);
         unset($data['thumbnail']);
 
@@ -359,7 +359,7 @@ class AssetAdminTest extends FunctionalTest
 
         $data = $assetAdmin->getObjectFromData($file);
 
-        // Thumbnail value is hard to predict, so we'll just check that it's there before unseting it.
+        // Thumbnail value is hard to predict, so we'll just check that it's there before unsetting it.
         $this->assertNotEmpty($data['thumbnail']);
         unset($data['thumbnail']);
 
@@ -408,7 +408,7 @@ class AssetAdminTest extends FunctionalTest
 
         $data = $assetAdmin->getObjectFromData($file);
 
-        // Thumbnail value is hard to predit, so we'll just check that it's there before unseting it.
+        // Thumbnail value is hard to predict, so we'll just check that it's there before unsetting it.
         $this->assertNotEmpty($data['thumbnail']);
         unset($data['thumbnail']);
 


### PR DESCRIPTION

## Description
Fixes typos in code comments:
- code/Forms/UploadField.php: coverted -> converted
- code/Controller/AssetAdmin.php: re-use -> reuse

Fixes typos in test files:
- tests/php/Controller/AssetAdminTest.php: unseting -> unsetting (3 occurrences), predit -> predict (2 occurrences)
- tests/behat/features/multi-file-upload-field.feature: mulitple -> multiple

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [ ] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
