### PR TITLE
FIX Incorrect File subclass when saved or published

### DIFF
--- a/code/Controller/AssetAdmin.php
+++ b/code/Controller/AssetAdmin.php
@@ -1236,14 +1236,8 @@ class AssetAdmin extends AssetAdminOpen implements PermissionProvider
             $newClass = File::get_class_for_file_extension($extension);
 
             // If the file extension has changed, change to the proper new class which represents it.
-            // The class will not change if the current class is a subclass of the new class.
-            // An exception is if new class is the generic File::class - to not change to the generic
-            // File::class make sure to register the file extension and your class to config in
-            // File::class_for_file_extension
             $currentClass = $record->getClassName();
-            if (!is_a($currentClass, $newClass ?? '', true) ||
-                ($currentClass !== $newClass && $newClass === File::class)
-            ) {
+            if ($this->shouldChangeFileClass($currentClass, $newClass, $extension)) {
                 $record = $record->newClassInstance($newClass);
 
                 // update the allowed category for the new file extension
@@ -1264,6 +1258,64 @@ class AssetAdmin extends AssetAdminOpen implements PermissionProvider
 
         // Note: Force return of schema / state in success result
         return $this->getRecordUpdatedResponse($record, $form);
+    }
+
+    /**
+     * Determine whether a record's class must be replaced to match its file extension.
+     *
+     * A class is kept if it can still represent the new extension. That includes subclasses
+     * of the class the extension maps to, so a project can subclass File (or Image) and have
+     * its records survive a save without having to register the subclass in
+     * File.class_for_file_extension.
+     *
+     * The exception is a class bound to a specific set of file types that no longer includes the
+     * record's extension - it cannot represent the file any more, so it is replaced. This is what
+     * demotes an Image to a File when its extension changes from .jpg to .pdf.
+     */
+    private function shouldChangeFileClass(string $currentClass, ?string $newClass, string $extension): bool
+    {
+        if (!$newClass || $currentClass === $newClass) {
+            return false;
+        }
+
+        // The current class cannot represent the new extension at all.
+        if (!is_a($currentClass, $newClass, true)) {
+            return true;
+        }
+
+        // The current class is a subclass of the new class. It is only replaced if it is bound to
+        // specific extensions and the new extension is not one of them.
+        $boundExtensions = $this->getExtensionsForClass($currentClass);
+
+        return $boundExtensions !== [] && !in_array(strtolower($extension), $boundExtensions, true);
+    }
+
+    /**
+     * Get the extensions a class can represent according to File.class_for_file_extension.
+     *
+     * An empty result means the class is not tied to any particular file type - which is the case
+     * for a project's own File subclass - so it is safe to keep for any extension its parent class can handle.
+     *
+     * @return string[]
+     */
+    private function getExtensionsForClass(string $class): array
+    {
+        $map = array_change_key_case(File::config()->get('class_for_file_extension') ?? [], CASE_LOWER);
+        $extensions = [];
+
+        foreach ($map as $mappedExtension => $mappedClass) {
+            // '*' and File::class are catch-alls that every File subclass matches, so they say
+            // nothing about whether a class is bound to specific extensions.
+            if ($mappedExtension === '*' || $mappedClass === File::class) {
+                continue;
+            }
+
+            if (is_a($class, $mappedClass, true)) {
+                $extensions[] = (string) $mappedExtension;
+            }
+        }
+
+        return $extensions;
     }
 
     public function unpublish(array $data, Form $form): HTTPResponse

--- a/tests/php/Controller/AssetAdminTest.php
+++ b/tests/php/Controller/AssetAdminTest.php
@@ -10,6 +10,8 @@ use SilverStripe\AssetAdmin\Tests\Controller\AssetAdminTest\TestFile;
 use SilverStripe\AssetAdmin\Tests\Controller\AssetAdminTest\TestObject;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Folder;
+use SilverStripe\Assets\Image;
+use SilverStripe\Control\HTTPResponse;
 use Silverstripe\Assets\Dev\TestAssetStore;
 use SilverStripe\Assets\Upload_Validator;
 use SilverStripe\Control\Director;
@@ -313,6 +315,67 @@ class AssetAdminTest extends FunctionalTest
         $this->assertFalse($response->isError());
         $folder1 = Folder::get()->byID($folder1ID);
         $this->assertEquals('folder1-renamed', $folder1->Name);
+    }
+
+    /**
+     * A project's own File subclass must survive a save.
+     * @see https://github.com/silverstripe/silverstripe-asset-admin/issues/1540
+     */
+    public function testSaveKeepsFileSubclass()
+    {
+        $file = TestFile::create();
+        $file->setFromString('dummy', 'folder1/subclass-test.pdf');
+        $file->write();
+        $file->publishSingle();
+
+        $response = $this->postFileEditForm($file, 'folder1/subclass-test.pdf');
+
+        $this->assertFalse($response->isError());
+        $this->assertSame(
+            TestFile::class,
+            File::get()->byID($file->ID)->ClassName,
+            'A File subclass should not be flattened to the generic File class'
+        );
+    }
+
+    /**
+     * A class registered against specific extensions must still be replaced when the file
+     * no longer has one of those extensions.
+     */
+    public function testSaveReplacesClassWhenExtensionNoLongerMatches()
+    {
+        $file = Image::create();
+        $file->setFromString('dummy', 'folder1/was-an-image.jpg');
+        $file->write();
+        $file->publishSingle();
+
+        $response = $this->postFileEditForm($file, 'folder1/was-an-image.pdf');
+
+        $this->assertFalse($response->isError());
+        $this->assertSame(
+            File::class,
+            File::get()->byID($file->ID)->ClassName,
+            'An Image should be demoted to File once its extension is no longer an image'
+        );
+    }
+
+    private function postFileEditForm(File $file, string $filename): HTTPResponse
+    {
+        return $this->post(
+            'admin/assets/fileEditForm/' . $file->ID,
+            [
+                'ID' => $file->ID,
+                'action_save' => 1,
+                'FileFilename' => $filename,
+                'Name' => basename($filename),
+                'Title' => $file->Title,
+                'SecurityID' => SecurityToken::inst()->getValue(),
+                'CanViewType' => 'Inherit',
+                'ViewerGroups' => 'unchanged',
+                'CanEditType' => 'Inherit',
+                'EditorGroups' => 'unchanged',
+            ]
+        );
     }
 
     public function testGetMinimalistObjectFromData()


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description

Fixes https://github.com/silverstripe/silverstripe-asset-admin/issues/1540.

A sub-class of `File` gets transformed into generic `File` if saved and published from the asset admin. This fix should prevent that while ensuring that current subclass with a set `class_for_file_extension` like Image is not affected.

## Manual testing steps
### Setup
* Install a generic CMS 6 site.
* Add a `File` subclass e.g. `ChildFile`

```php
<?php

use SilverStripe\Assets\File;

class ChildFile extends File
{
}
```

* Add task that converts an uploaded pdf file to the file subclass. This task is obviously a simulation but actual use-case would be an update from an external source that updates to the file subclass. **Note:** file uploaded should be published first before running the task.

```php
<?php

use SilverStripe\Assets\File;
use SilverStripe\Assets\Folder;
use SilverStripe\Dev\BuildTask;
use SilverStripe\PolyExecution\PolyOutput;
use SilverStripe\Security\Security;
use Symfony\Component\Console\Command\Command;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Input\InputOption;

class ConvertPDFToChildFile extends BuildTask
{
    protected static string $commandName = 'convert-pdf-to-child-file';

    protected string $title = 'Convert a PDF file to a child file';

    public function getOptions(): array
    {
        return [
            new InputOption(
                'id',
                null,
                InputOption::VALUE_REQUIRED,
                'ID of any existing File record to convert to ChildFile. Omit to create a new record.'
            ),
        ];
    }

    protected function execute(InputInterface $input, PolyOutput $output): int
    {
        $id = $input->getOption('id');
        $file = $this->convertExisting((int) $id, $output);

        if (!$file) {
            return Command::FAILURE;
        }

        $file->publishSingle();

        return Command::SUCCESS;
    }

    /**
     * Convert an existing record in place. newClassInstance() keeps the same ID and
     * the same underlying asset - only ClassName changes.
     */
    private function convertExisting(int $id, PolyOutput $output): ?File
    {
        $record = File::get()->byID($id);

        if (!$record) {
            $output->writeln("<error>No File record found with ID $id</error>");
            return null;
        }

        if ($record instanceof Folder) {
            $output->writeln("<error>#$id is a Folder, not a file</error>");
            return null;
        }

        if ($record instanceof ChildFile) {
            $output->writeln("<comment>File #$id is already a ChildFile - nothing to convert</comment>");
            return $record;
        }

        $output->writeln(sprintf(
            'Converting #%d (%s) from %s to ChildFile',
            $id,
            $record->getFilename(),
            $record->ClassName
        ));

        $record = $record->newClassInstance(ChildFile::class);
        $record->write();

        return $record;
    }

}

```

### How to replicate

1. Create a subclass of File, say ChildFile (see setup).
2. Upload a pdf document on the files admin section. Take note of its `file-id`.
3. Save and publish
4. Run the task to convert to the file subclass using `sake task:convert-pdf-to-child-file --id=<file-id>`
5. View the ChildFile record on the CMS
6. Unpublish the file then re-publish.
7. The class of the record is now File (instead of ChildFile). 

## Issues

The subclass is not retained which could be an issue if both file::class and its subclass should co-exist while not changing the `class_for_file_extension` to the file subclass like, say, an image. 

- #

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
